### PR TITLE
Fix critical bugs in transport, client, subscription, and fossil paths

### DIFF
--- a/src/Centrifugal.Centrifuge/Client.cs
+++ b/src/Centrifugal.Centrifuge/Client.cs
@@ -1119,7 +1119,20 @@ namespace Centrifugal.Centrifuge
                 _pendingCalls[_pendingConnectCommand.Id] = connectTcs;
             }
 
-            await _transport.OpenAsync(initialData: initialData).ConfigureAwait(false);
+            try
+            {
+                await _transport.OpenAsync(initialData: initialData).ConfigureAwait(false);
+            }
+            catch
+            {
+                // OpenAsync failed before SendConnectCommandAsync's finally could clean up the
+                // pre-registered emulation entry — remove it here to avoid leaking _pendingCalls slots.
+                if (_pendingConnectCommand != null)
+                {
+                    _pendingCalls.TryRemove(_pendingConnectCommand.Id, out _);
+                }
+                throw;
+            }
         }
 
         private ITransport CreateTransport(CentrifugeTransportType transportType, string endpoint)
@@ -1864,8 +1877,10 @@ namespace Centrifugal.Centrifuge
                 return;
             }
 
-            _reconnectCts?.Cancel();
+            var oldReconnectCts = _reconnectCts;
             _reconnectCts = new CancellationTokenSource();
+            oldReconnectCts?.Cancel();
+            oldReconnectCts?.Dispose();
 
             int delay = Utilities.CalculateBackoff(
                 _reconnectAttempts++,
@@ -2027,7 +2042,11 @@ namespace Centrifugal.Centrifuge
                             var delimitedCommand = ms.ToArray();
 
                             var emulationEndpoint = GetEmulationEndpoint();
-                            _transport.SendEmulationAsync(delimitedCommand, _session, _node, emulationEndpoint, CancellationToken.None);
+                            // Fire-and-forget: this runs on the receive thread; observe the
+                            // task so a faulted send doesn't surface as an unobserved exception.
+                            _ = _transport.SendEmulationAsync(delimitedCommand, _session, _node, emulationEndpoint, CancellationToken.None).ContinueWith(
+                                t => { _ = t.Exception; },
+                                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
                         }
                         else
                         {

--- a/src/Centrifugal.Centrifuge/Fossil.cs
+++ b/src/Centrifugal.Centrifuge/Fossil.cs
@@ -215,7 +215,7 @@ namespace Centrifugal.Centrifuge
                             total += cnt;
                             if (total > limit)
                                 throw new InvalidOperationException("copy exceeds output file size");
-                            if (ofst + cnt > lenSrc)
+                            if ((long)ofst + cnt > lenSrc)
                                 throw new InvalidOperationException("copy extends past end of input");
 
                             zOut.PutArray(source, (int)ofst, (int)(ofst + cnt));
@@ -228,7 +228,7 @@ namespace Centrifugal.Centrifuge
                             total += cnt;
                             if (total > limit)
                                 throw new InvalidOperationException("insert command gives an output larger than predicted");
-                            if (cnt > lenDelta)
+                            if (zDelta._pos + cnt > lenDelta)
                                 throw new InvalidOperationException("insert count exceeds size of delta");
 
                             zOut.PutArray(delta, (int)zDelta._pos, (int)(zDelta._pos + cnt));

--- a/src/Centrifugal.Centrifuge/Subscription.cs
+++ b/src/Centrifugal.Centrifuge/Subscription.cs
@@ -821,8 +821,10 @@ namespace Centrifugal.Centrifuge
                 return;
             }
 
-            _resubscribeCts?.Cancel();
+            var oldResubscribeCts = _resubscribeCts;
             _resubscribeCts = new CancellationTokenSource();
+            oldResubscribeCts?.Cancel();
+            oldResubscribeCts?.Dispose();
 
             int delay = Utilities.CalculateBackoff(
                 _resubscribeAttempts++,

--- a/src/Centrifugal.Centrifuge/Transports/HttpStreamTransport.cs
+++ b/src/Centrifugal.Centrifuge/Transports/HttpStreamTransport.cs
@@ -18,6 +18,7 @@ namespace Centrifugal.Centrifuge.Transports
     {
         private readonly string _endpoint;
         private readonly HttpClient _httpClient;
+        private readonly bool _ownsHttpClient;
         private CancellationTokenSource? _receiveCts;
         private Task? _receiveTask;
         private bool _disposed;
@@ -62,10 +63,12 @@ namespace Centrifugal.Centrifuge.Transports
                 _httpClient = new HttpClient();
                 // Configure for streaming - no timeout on the connection itself
                 _httpClient.Timeout = System.Threading.Timeout.InfiniteTimeSpan;
+                _ownsHttpClient = true;
             }
             else
             {
                 _httpClient = httpClient;
+                _ownsHttpClient = false;
             }
         }
 
@@ -81,16 +84,8 @@ namespace Centrifugal.Centrifuge.Transports
             {
                 var openedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-                EventHandler? openedHandler = null;
-                openedHandler = (s, e) =>
-                {
-                    openedTcs.TrySetResult(true);
-                    Opened -= openedHandler;
-                };
-                Opened += openedHandler;
-
                 _receiveCts = new CancellationTokenSource();
-                _receiveTask = ReceiveLoopAsync(initialData ?? Array.Empty<byte>(), _receiveCts.Token);
+                _receiveTask = ReceiveLoopAsync(initialData ?? Array.Empty<byte>(), openedTcs, _receiveCts.Token);
 
                 // Wait for the connection to open or timeout
                 using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -101,6 +96,9 @@ namespace Centrifugal.Centrifuge.Transports
                 {
                     throw new TimeoutException("Timeout waiting for HTTP stream connection to open");
                 }
+
+                // Propagate any exception the receive loop set on openedTcs (early HTTP failure, etc.)
+                await openedTcs.Task.ConfigureAwait(false);
 
                 _isOpen = true;
             }
@@ -174,7 +172,7 @@ namespace Centrifugal.Centrifuge.Transports
             }
         }
 
-        private async Task ReceiveLoopAsync(byte[] initialData, CancellationToken cancellationToken)
+        private async Task ReceiveLoopAsync(byte[] initialData, TaskCompletionSource<bool> openedTcs, CancellationToken cancellationToken)
         {
             try
             {
@@ -214,12 +212,15 @@ namespace Centrifugal.Centrifuge.Transports
                         closeCode = CentrifugeConnectingCodes.TransportClosed;
                     }
 
+                    // Signal the early failure to OpenAsync so it doesn't wait for the 10s timeout
+                    openedTcs.TrySetException(new CentrifugeException(CentrifugeErrorCodes.TransportClosed, errorReason, true));
                     Closed?.Invoke(this, new TransportClosedEventArgs(code: closeCode, reason: errorReason));
                     return;
                 }
 
 
                 // Connection established successfully
+                openedTcs.TrySetResult(true);
                 Opened?.Invoke(this, EventArgs.Empty);
 
                 using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -241,10 +242,13 @@ namespace Centrifugal.Centrifuge.Transports
             }
             catch (OperationCanceledException)
             {
-                // Normal cancellation
+                // Normal cancellation — unblock OpenAsync if it's still waiting
+                openedTcs.TrySetCanceled();
             }
             catch (Exception ex)
             {
+                // Unblock OpenAsync if the failure happened before the connection opened
+                openedTcs.TrySetException(ex);
                 Error?.Invoke(this, ex);
                 // Close code should have been set by earlier status check if it was an HTTP error
                 Closed?.Invoke(this, new TransportClosedEventArgs(exception: ex));
@@ -259,6 +263,11 @@ namespace Centrifugal.Centrifuge.Transports
 
             _receiveCts?.Cancel();
             _receiveCts?.Dispose();
+
+            if (_ownsHttpClient)
+            {
+                _httpClient.Dispose();
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Seven correctness fixes spanning the HTTP stream transport, the client/subscription reconnect paths, the emulation pong path, and the Fossil delta decoder. Each was confirmed by reading the surrounding code; no speculative changes.

### `HttpStreamTransport`
- **Silent 10s timeout on early HTTP failure.** The receive loop fired `Closed` and returned without settling the open-TCS, so `OpenAsync` always waited the full 10s before throwing `TimeoutException`. The TCS is now passed into `ReceiveLoopAsync` and signaled via `TrySetResult` / `TrySetException` / `TrySetCanceled` on every termination path; `OpenAsync` returns immediately on early failure.
- **`HttpClient` leak when transport owns the client.** `Dispose()` only disposed `_receiveCts`. Every reconnect that built a fresh transport leaked an `HttpClient` plus its `HttpClientHandler` connection pool. Now tracked via `_ownsHttpClient` and disposed in `Dispose` when owned.

### `Client.cs`
- **Orphaned `_pendingCalls` entry on emulation `OpenAsync` throw.** The emulation connect TCS was deliberately registered *before* `OpenAsync` to avoid a reply-before-registration race, but had no cleanup if `OpenAsync` threw. Failed reconnects to an emulation transport accumulated stale entries until the next `SetDisconnectedAsync`. Now wrapped with `try/catch + TryRemove` while preserving the original race-avoidance intent.
- **`CancellationTokenSource` leak on reconnect.** `_reconnectCts?.Cancel(); _reconnectCts = new CTS();` cancelled but never disposed the old CTS before overwriting it. Switched to save-old/swap/cancel/dispose.
- **Emulation pong was fire-and-forget without exception observation.** The matching WebSocket path used `ContinueWith(OnlyOnFaulted, ExecuteSynchronously)`; the emulation path discarded the Task entirely, so a faulted POST surfaced as an unobserved task exception. Same observation pattern applied.

### `Subscription.cs`
- **`CancellationTokenSource` leak on resubscribe.** Identical pattern to the client-side reconnect leak; same fix.

### `Fossil.cs`
- **Insert command bounds check too loose.** `if (cnt > lenDelta)` only caught counts larger than the entire delta, missing the case where the running read position plus count overruns the buffer. A malformed delta with a near-end insert raised `IndexOutOfRangeException` from `Writer.PutArray` instead of the intended `InvalidOperationException`. Changed to `if (zDelta._pos + cnt > lenDelta)`.
- **Copy command bounds check overflows on adversarial input.** `ofst + cnt > lenSrc` did the addition in `uint` arithmetic; an `ofst` near `uint.MaxValue` wrapped past the comparison, then `(int)ofst` cast negative and tripped `IndexOutOfRangeException`. Addition now done in `long` to reject the input cleanly.

## Test plan

- [x] `dotnet build` — clean, 0 warnings, 0 errors across `netstandard2.1`, `net6.0`, `net8.0`, `net9.0`, `net10.0`
- [x] `dotnet test` — 105/105 pass
- [ ] Manual regression: confirm reconnect cycles against an HTTP-stream-only deployment no longer accumulate `_pendingCalls` entries or HTTP handler instances under load
- [ ] Manual: confirm an HTTP-stream connect against an unreachable / 4xx endpoint fails fast (no 10s wait)

🤖 Generated with [Claude Code](https://claude.com/claude-code)