### PR TITLE
Fix ReadyAsync race that left subscribe/connect promises unresolved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ BenchmarkDotNet.Artifacts/
 
 # Local History for Visual Studio Code
 .history/
+
+# Claude Code local config
+.claude/

--- a/src/Centrifugal.Centrifuge/Client.cs
+++ b/src/Centrifugal.Centrifuge/Client.cs
@@ -349,56 +349,64 @@ namespace Centrifugal.Centrifuge
         /// <returns>A task that completes when connected.</returns>
         public Task ReadyAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
         {
-            switch (_state)
+            TaskCompletionSource<bool> tcs;
+            int promiseId;
+
+            // Hold _stateChangeLock across both the state check and the registration so we
+            // don't race with HandleConnectReply / SetDisconnectedAsync resolving promises
+            // between us reading _state and inserting the tcs into _readyPromises.
+            lock (_stateChangeLock)
             {
-                case CentrifugeClientState.Disconnected:
-                    return Task.FromException(new CentrifugeException(CentrifugeErrorCodes.ClientDisconnected, "client disconnected"));
+                switch (_state)
+                {
+                    case CentrifugeClientState.Disconnected:
+                        return Task.FromException(new CentrifugeException(CentrifugeErrorCodes.ClientDisconnected, "client disconnected"));
 
-                case CentrifugeClientState.Connected:
-                    return Task.CompletedTask;
+                    case CentrifugeClientState.Connected:
+                        return Task.CompletedTask;
+                }
 
-                default:
-                    var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-                    var promiseId = NextPromiseId();
-                    _readyPromises[promiseId] = tcs;
-
-                    CancellationTokenSource? timeoutCts = null;
-                    CancellationTokenRegistration timeoutRegistration = default;
-                    CancellationTokenRegistration cancellationRegistration = default;
-
-                    if (timeout.HasValue)
-                    {
-                        timeoutCts = new CancellationTokenSource(timeout.Value);
-                        timeoutRegistration = timeoutCts.Token.Register(() =>
-                        {
-                            if (_readyPromises.TryRemove(promiseId, out var promise))
-                            {
-                                promise.TrySetException(new CentrifugeException(CentrifugeErrorCodes.Timeout, "timeout"));
-                            }
-                        });
-                    }
-
-                    if (cancellationToken.CanBeCanceled)
-                    {
-                        cancellationRegistration = cancellationToken.Register(() =>
-                        {
-                            if (_readyPromises.TryRemove(promiseId, out var promise))
-                            {
-                                promise.TrySetCanceled(cancellationToken);
-                            }
-                        });
-                    }
-
-                    // Dispose registrations when task completes to prevent memory leaks
-                    tcs.Task.ContinueWith(_ =>
-                    {
-                        timeoutRegistration.Dispose();
-                        cancellationRegistration.Dispose();
-                        timeoutCts?.Dispose();
-                    }, TaskContinuationOptions.ExecuteSynchronously);
-
-                    return tcs.Task;
+                tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                promiseId = NextPromiseId();
+                _readyPromises[promiseId] = tcs;
             }
+
+            CancellationTokenSource? timeoutCts = null;
+            CancellationTokenRegistration timeoutRegistration = default;
+            CancellationTokenRegistration cancellationRegistration = default;
+
+            if (timeout.HasValue)
+            {
+                timeoutCts = new CancellationTokenSource(timeout.Value);
+                timeoutRegistration = timeoutCts.Token.Register(() =>
+                {
+                    if (_readyPromises.TryRemove(promiseId, out var promise))
+                    {
+                        promise.TrySetException(new CentrifugeException(CentrifugeErrorCodes.Timeout, "timeout"));
+                    }
+                });
+            }
+
+            if (cancellationToken.CanBeCanceled)
+            {
+                cancellationRegistration = cancellationToken.Register(() =>
+                {
+                    if (_readyPromises.TryRemove(promiseId, out var promise))
+                    {
+                        promise.TrySetCanceled(cancellationToken);
+                    }
+                });
+            }
+
+            // Dispose registrations when task completes to prevent memory leaks
+            tcs.Task.ContinueWith(_ =>
+            {
+                timeoutRegistration.Dispose();
+                cancellationRegistration.Dispose();
+                timeoutCts?.Dispose();
+            }, TaskContinuationOptions.ExecuteSynchronously);
+
+            return tcs.Task;
         }
 
 
@@ -1457,9 +1465,15 @@ namespace Centrifugal.Centrifuge
             _session = connectResult.Session;
             _node = connectResult.Node;
 
-            SetState(CentrifugeClientState.Connected);
-
-            _transportIsOpen = true;
+            // Hold _stateChangeLock across the state transition and ResolvePromises so a
+            // ReadyAsync caller can't observe Connecting, miss our resolve, and then register
+            // a tcs that nobody will complete.
+            lock (_stateChangeLock)
+            {
+                SetState(CentrifugeClientState.Connected);
+                _transportIsOpen = true;
+                ResolvePromises();
+            }
 
             Connected?.Invoke(this, new CentrifugeConnectedEventArgs(
                 connectResult.Client,
@@ -1473,9 +1487,6 @@ namespace Centrifugal.Centrifuge
             ClearRefreshTimer();
             _refreshAttempts = 0;
             _refreshRequired = false;
-
-            // Resolve ready promises
-            ResolvePromises();
 
             // Schedule token refresh if token expires
             if (connectResult.Expires)

--- a/src/Centrifugal.Centrifuge/Subscription.cs
+++ b/src/Centrifugal.Centrifuge/Subscription.cs
@@ -132,56 +132,64 @@ namespace Centrifugal.Centrifuge
         /// <returns>A task that completes when subscribed.</returns>
         public Task ReadyAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
         {
-            switch (_state)
+            TaskCompletionSource<bool> tcs;
+            int promiseId;
+
+            // Hold _stateChangeLock across both the state check and the registration so we
+            // don't race with HandleSubscribeReply / SetUnsubscribedAsync resolving promises
+            // between us reading _state and inserting the tcs into _readyPromises.
+            lock (_stateChangeLock)
             {
-                case CentrifugeSubscriptionState.Unsubscribed:
-                    return Task.FromException(new CentrifugeException(CentrifugeErrorCodes.SubscriptionUnsubscribed, "subscription unsubscribed"));
+                switch (_state)
+                {
+                    case CentrifugeSubscriptionState.Unsubscribed:
+                        return Task.FromException(new CentrifugeException(CentrifugeErrorCodes.SubscriptionUnsubscribed, "subscription unsubscribed"));
 
-                case CentrifugeSubscriptionState.Subscribed:
-                    return Task.CompletedTask;
+                    case CentrifugeSubscriptionState.Subscribed:
+                        return Task.CompletedTask;
+                }
 
-                default:
-                    var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-                    var promiseId = NextPromiseId();
-                    _readyPromises[promiseId] = tcs;
-
-                    CancellationTokenSource? timeoutCts = null;
-                    CancellationTokenRegistration timeoutRegistration = default;
-                    CancellationTokenRegistration cancellationRegistration = default;
-
-                    if (timeout.HasValue)
-                    {
-                        timeoutCts = new CancellationTokenSource(timeout.Value);
-                        timeoutRegistration = timeoutCts.Token.Register(() =>
-                        {
-                            if (_readyPromises.TryRemove(promiseId, out var promise))
-                            {
-                                promise.TrySetException(new CentrifugeException(CentrifugeErrorCodes.Timeout, "timeout"));
-                            }
-                        });
-                    }
-
-                    if (cancellationToken.CanBeCanceled)
-                    {
-                        cancellationRegistration = cancellationToken.Register(() =>
-                        {
-                            if (_readyPromises.TryRemove(promiseId, out var promise))
-                            {
-                                promise.TrySetCanceled(cancellationToken);
-                            }
-                        });
-                    }
-
-                    // Dispose registrations when task completes to prevent memory leaks
-                    tcs.Task.ContinueWith(_ =>
-                    {
-                        timeoutRegistration.Dispose();
-                        cancellationRegistration.Dispose();
-                        timeoutCts?.Dispose();
-                    }, TaskContinuationOptions.ExecuteSynchronously);
-
-                    return tcs.Task;
+                tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                promiseId = NextPromiseId();
+                _readyPromises[promiseId] = tcs;
             }
+
+            CancellationTokenSource? timeoutCts = null;
+            CancellationTokenRegistration timeoutRegistration = default;
+            CancellationTokenRegistration cancellationRegistration = default;
+
+            if (timeout.HasValue)
+            {
+                timeoutCts = new CancellationTokenSource(timeout.Value);
+                timeoutRegistration = timeoutCts.Token.Register(() =>
+                {
+                    if (_readyPromises.TryRemove(promiseId, out var promise))
+                    {
+                        promise.TrySetException(new CentrifugeException(CentrifugeErrorCodes.Timeout, "timeout"));
+                    }
+                });
+            }
+
+            if (cancellationToken.CanBeCanceled)
+            {
+                cancellationRegistration = cancellationToken.Register(() =>
+                {
+                    if (_readyPromises.TryRemove(promiseId, out var promise))
+                    {
+                        promise.TrySetCanceled(cancellationToken);
+                    }
+                });
+            }
+
+            // Dispose registrations when task completes to prevent memory leaks
+            tcs.Task.ContinueWith(_ =>
+            {
+                timeoutRegistration.Dispose();
+                cancellationRegistration.Dispose();
+                timeoutCts?.Dispose();
+            }, TaskContinuationOptions.ExecuteSynchronously);
+
+            return tcs.Task;
         }
 
 
@@ -688,7 +696,12 @@ namespace Centrifugal.Centrifuge
 
         private void HandleSubscribeReply(SubscribeResult result)
         {
-            // Check if subscription was unsubscribed while subscribe was in-flight
+            bool wasRecovering = _streamPosition != null;
+            bool recovered = result.Recovered;
+
+            // Hold _stateChangeLock across the unsubscribed-check, the state transition
+            // and ResolvePromises so a ReadyAsync caller can't observe Subscribing,
+            // miss our resolve, and then register a tcs that nobody will complete.
             lock (_stateChangeLock)
             {
                 if (_state == CentrifugeSubscriptionState.Unsubscribed)
@@ -696,42 +709,39 @@ namespace Centrifugal.Centrifuge
                     // Subscription was unsubscribed during subscribe, ignore the reply
                     return;
                 }
+
+                if (result.Positioned)
+                {
+                    _streamPosition = new CentrifugeStreamPosition(result.Offset, result.Epoch);
+                }
+
+                // Check if delta compression was negotiated with server
+                if (result.Delta)
+                {
+                    _deltaNegotiated = true;
+                }
+                else
+                {
+                    _deltaNegotiated = false;
+                    _prevValue = null;
+                }
+
+                // Clear refresh timer and reset attempts
+                ClearRefreshTimer();
+                _refreshAttempts = 0;
+                _refreshRequired = false;
+
+                // Schedule token refresh if token expires
+                if (result.Expires)
+                {
+                    ScheduleTokenRefresh(result.Ttl);
+                }
+
+                SetState(CentrifugeSubscriptionState.Subscribed);
+
+                // Resolve ready promises
+                ResolvePromises();
             }
-
-            bool wasRecovering = _streamPosition != null;
-            bool recovered = result.Recovered;
-
-            if (result.Positioned)
-            {
-                _streamPosition = new CentrifugeStreamPosition(result.Offset, result.Epoch);
-            }
-
-            // Check if delta compression was negotiated with server
-            if (result.Delta)
-            {
-                _deltaNegotiated = true;
-            }
-            else
-            {
-                _deltaNegotiated = false;
-                _prevValue = null;
-            }
-
-            // Clear refresh timer and reset attempts
-            ClearRefreshTimer();
-            _refreshAttempts = 0;
-            _refreshRequired = false;
-
-            // Schedule token refresh if token expires
-            if (result.Expires)
-            {
-                ScheduleTokenRefresh(result.Ttl);
-            }
-
-            SetState(CentrifugeSubscriptionState.Subscribed);
-
-            // Resolve ready promises
-            ResolvePromises();
 
             Subscribed?.Invoke(this, new CentrifugeSubscribedEventArgs(
                 wasRecovering,


### PR DESCRIPTION
## Summary
- `ReadyAsync` read `_state` and registered its `TaskCompletionSource` in `_readyPromises` in two separate steps. If the subscribe/connect reply landed between those steps, `HandleSubscribeReply` / `HandleConnectReply` ran `SetState` followed by `ResolvePromises` over an empty dictionary, and the tcs registered immediately afterwards never completed — the caller hung until its 5 s timeout.
- The reject paths (`SetUnsubscribedAsync` / `SetDisconnectedAsync`) already serialized state + `RejectPromises` under `_stateChangeLock`; only the resolve paths were unguarded, so the race only affected the success direction.
- Now hold `_stateChangeLock` across the state check + tcs registration in both `ReadyAsync` methods, and across `SetState` + `ResolvePromises` in the reply handlers. A tcs registered while still in `Subscribing`/`Connecting` is now either resolved by `ResolvePromises` or observes the post-transition state and short-circuits with a completed task.

This is the bug behind the intermittent CI failure of `SubscribesAndUnsubscribesFromManySubsWithGetToken` on the WebSocket transport. WebSocket subscribe roundtrips are low-latency, so with five subs and `GetToken` delays randomized 0–100 ms, the fastest sub frequently completes before the test's `foreach … ReadyAsync` reaches it; HttpStream is slower per request, so the window almost never hits.

## Test plan
- [x] Reproduced the failure locally on WebSocket within ~13 iterations of `SubscribesAndUnsubscribesFromManySubsWithGetToken`.
- [x] Post-fix: 100 consecutive runs of that test pass.
- [x] Post-fix: 20 runs of the full 105-test suite pass.
- [ ] Confirm CI green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)