### PR TITLE
Connection reliability and thread-safety hardening

### DIFF
--- a/src/Centrifugal.Centrifuge/Client.cs
+++ b/src/Centrifugal.Centrifuge/Client.cs
@@ -40,7 +40,8 @@ namespace Centrifugal.Centrifuge
         private readonly object _commandBatchLock = new object();
 
         private ITransport? _transport;
-        private CentrifugeClientState _state = CentrifugeClientState.Disconnected;
+        private volatile CentrifugeClientState _state = CentrifugeClientState.Disconnected;
+        private int _epoch;
         private int _commandId;
         private int _reconnectAttempts;
         private CancellationTokenSource? _reconnectCts;
@@ -54,19 +55,19 @@ namespace Centrifugal.Centrifuge
         private string? _clientId;
         private string _session = string.Empty;
         private string _node = string.Empty;
-        private Command? _pendingConnectCommand; // For emulation transports, stores the connect command sent in initialData
-        private bool _disposed;
+        private volatile Command? _pendingConnectCommand; // For emulation transports, stores the connect command sent in initialData
+        private volatile int _disposed;
         private int _refreshAttempts;
         private bool _refreshRequired;
         private int _currentTransportIndex;
         private bool _transportWasOpen;
         private int _promiseId;
-        private bool _transportIsOpen;
+        private volatile bool _transportIsOpen;
         private Timer? _commandBatchTimer;
         private bool _commandBatchPending;
         private int _commandBatchSize;
 #if NET6_0_OR_GREATER
-        private static Microsoft.JSInterop.IJSRuntime? _globalJSRuntime;
+        private static volatile Microsoft.JSInterop.IJSRuntime? _globalJSRuntime;
         private readonly Microsoft.JSInterop.IJSRuntime? _jsRuntime;
 #endif
         private readonly ILogger? _logger;
@@ -317,18 +318,18 @@ namespace Centrifugal.Centrifuge
         /// </summary>
         public void Connect()
         {
-            if (_state == CentrifugeClientState.Connected)
+            ThrowIfDisposed();
+            lock (_stateChangeLock)
             {
-                return;
+                if (_state == CentrifugeClientState.Connected || _state == CentrifugeClientState.Connecting) return;
             }
-
-            if (_state == CentrifugeClientState.Connecting)
-            {
-                return;
-            }
-
-            _reconnectAttempts = 0;
             StartConnecting();
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (System.Threading.Interlocked.CompareExchange(ref _disposed, 0, 0) != 0)
+                throw new ObjectDisposedException(nameof(CentrifugeClient));
         }
 
         /// <summary>
@@ -336,7 +337,7 @@ namespace Centrifugal.Centrifuge
         /// </summary>
         public void Disconnect()
         {
-            _ = SetDisconnectedAsync(CentrifugeDisconnectedCodes.DisconnectCalled, "disconnect called", false);
+            _ = SetDisconnectedAsync(CentrifugeDisconnectedCodes.DisconnectCalled, "disconnect called");
         }
 
         /// <summary>
@@ -349,6 +350,9 @@ namespace Centrifugal.Centrifuge
         /// <returns>A task that completes when connected.</returns>
         public Task ReadyAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
         {
+            if (System.Threading.Interlocked.CompareExchange(ref _disposed, 0, 0) != 0)
+                return Task.FromException(new ObjectDisposedException(nameof(CentrifugeClient)));
+
             TaskCompletionSource<bool> tcs;
             int promiseId;
 
@@ -418,18 +422,17 @@ namespace Centrifugal.Centrifuge
         /// <returns>The subscription instance.</returns>
         public CentrifugeSubscription NewSubscription(string channel, CentrifugeSubscriptionOptions? options = null)
         {
+            ThrowIfDisposed();
             if (string.IsNullOrWhiteSpace(channel))
             {
                 throw new ArgumentException("Channel cannot be null or empty", nameof(channel));
             }
 
-            if (_subscriptions.ContainsKey(channel))
+            var subscription = new CentrifugeSubscription(this, channel, options);
+            if (!_subscriptions.TryAdd(channel, subscription))
             {
                 throw new CentrifugeDuplicateSubscriptionException(channel);
             }
-
-            var subscription = new CentrifugeSubscription(this, channel, options);
-            _subscriptions[channel] = subscription;
             return subscription;
         }
 
@@ -452,12 +455,12 @@ namespace Centrifugal.Centrifuge
         {
             if (subscription == null) throw new ArgumentNullException(nameof(subscription));
 
-            if (subscription.State != CentrifugeSubscriptionState.Unsubscribed)
-            {
-                subscription.Unsubscribe();
-            }
+            subscription.Unsubscribe();
 
-            _subscriptions.TryRemove(subscription.Channel, out _);
+            if (_subscriptions.TryRemove(subscription.Channel, out var removed))
+            {
+                removed.Dispose();
+            }
         }
 
 
@@ -553,6 +556,9 @@ namespace Centrifugal.Centrifuge
             // Wait for client to be ready
             await ReadyAsync(_options.Timeout, cancellationToken).ConfigureAwait(false);
 
+            // Send commands have no reply (id stays 0). Route through SendCommandsImmediateAsync
+            // so the command gets varint-framed and uses the emulation endpoint when the
+            // transport requires it.
             var cmd = new Command
             {
                 Send = new SendRequest
@@ -561,12 +567,7 @@ namespace Centrifugal.Centrifuge
                 }
             };
 
-            if (_transport == null || _state != CentrifugeClientState.Connected)
-            {
-                throw new CentrifugeException(CentrifugeErrorCodes.ClientDisconnected, "Client is not connected");
-            }
-
-            await _transport.SendAsync(cmd.ToByteArray(), cancellationToken).ConfigureAwait(false);
+            await SendCommandsImmediateAsync(new[] { cmd }, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -763,13 +764,15 @@ namespace Centrifugal.Centrifuge
 
         internal async Task<Reply> SendCommandAsync(Command command, CancellationToken cancellationToken)
         {
-            if (_transport == null || (_state != CentrifugeClientState.Connected && _state != CentrifugeClientState.Connecting))
+            var tcs = new TaskCompletionSource<Reply>(TaskCreationOptions.RunContinuationsAsynchronously);
+            lock (_stateChangeLock)
             {
-                throw new CentrifugeException(CentrifugeErrorCodes.ClientDisconnected, "Client is not connected");
+                if (_transport == null || (_state != CentrifugeClientState.Connected && _state != CentrifugeClientState.Connecting))
+                {
+                    throw new CentrifugeException(CentrifugeErrorCodes.ClientDisconnected, "Client is not connected");
+                }
+                _pendingCalls[command.Id] = tcs;
             }
-
-            var tcs = new TaskCompletionSource<Reply>();
-            _pendingCalls[command.Id] = tcs;
 
             try
             {
@@ -797,6 +800,9 @@ namespace Centrifugal.Centrifuge
 
                 if (completedTask != tcs.Task)
                 {
+                    // Distinguish caller cancellation from per-command timeout so
+                    // standard `await x.WaitAsync(ct)` patterns observe OCE, not a timeout.
+                    cancellationToken.ThrowIfCancellationRequested();
                     throw new CentrifugeTimeoutException();
                 }
 
@@ -810,7 +816,16 @@ namespace Centrifugal.Centrifuge
 
         private async Task SendCommandsImmediateAsync(IEnumerable<Command> commands, CancellationToken cancellationToken)
         {
-            if (_transport == null)
+            ITransport? transport;
+            string? session;
+            string? node;
+            lock (_stateChangeLock)
+            {
+                transport = _transport;
+                session = _session;
+                node = _node;
+            }
+            if (transport == null)
             {
                 throw new CentrifugeException(CentrifugeErrorCodes.ClientDisconnected, "Client is not connected");
             }
@@ -824,9 +839,9 @@ namespace Centrifugal.Centrifuge
             // Don't send connect command for emulation transports - it was already sent during OpenAsync
             bool isConnectCommand = firstCommand.Connect != null;
 
-            if (!isConnectCommand || !_transport.UsesEmulation)
+            if (!isConnectCommand || !transport.UsesEmulation)
             {
-                if (_transport.UsesEmulation)
+                if (transport.UsesEmulation)
                 {
                     // For emulation transports, we need to pre-wrap commands with varint delimiters
                     // because SendEmulationAsync doesn't add them
@@ -838,7 +853,7 @@ namespace Centrifugal.Centrifuge
                     var delimitedCommands = ms.ToArray();
 
                     var emulationEndpoint = GetEmulationEndpoint();
-                    await _transport.SendEmulationAsync(delimitedCommands, _session, _node, emulationEndpoint, cancellationToken).ConfigureAwait(false);
+                    await transport.SendEmulationAsync(delimitedCommands, session, node, emulationEndpoint, cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
@@ -856,7 +871,7 @@ namespace Centrifugal.Centrifuge
                         _logger?.LogDebug($"Sending {commandsList.Count} commands in single frame ({delimitedData.Length} bytes)");
                     }
 
-                    await _transport.SendAsync(delimitedData, cancellationToken).ConfigureAwait(false);
+                    await transport.SendAsync(delimitedData, cancellationToken).ConfigureAwait(false);
                 }
             }
         }
@@ -905,16 +920,15 @@ namespace Centrifugal.Centrifuge
 
         private async Task FlushCommandBatchAsync()
         {
+            lock (_stateChangeLock)
+            {
+                if (_state != CentrifugeClientState.Connected && _state != CentrifugeClientState.Connecting) return;
+            }
+
             List<Command> commandsToSend;
 
             lock (_commandBatchLock)
             {
-                // Check client state before taking commands from batch
-                if (_state != CentrifugeClientState.Connected && _state != CentrifugeClientState.Connecting)
-                {
-                    return;
-                }
-
                 if (!_transportIsOpen)
                 {
                     return;
@@ -951,7 +965,9 @@ namespace Centrifugal.Centrifuge
 
             // Auto-construct emulation endpoint from transport endpoint
             // Emulation endpoint is at root level: http://host:port/emulation
-            string endpoint = _endpoint ?? _transportEndpoints?[_currentTransportIndex].Endpoint ?? throw new CentrifugeConfigurationException("No endpoint configured");
+            int idx;
+            lock (_stateChangeLock) { idx = _currentTransportIndex; }
+            string endpoint = _endpoint ?? _transportEndpoints?[idx].Endpoint ?? throw new CentrifugeConfigurationException("No endpoint configured");
 
             var uri = new Uri(endpoint);
             return $"{uri.Scheme}://{uri.Authority}/emulation";
@@ -959,7 +975,17 @@ namespace Centrifugal.Centrifuge
 
         private void StartConnecting()
         {
-            SetState(CentrifugeClientState.Connecting);
+            // State check + SetState must be atomic so a concurrent SetDisconnectedAsync
+            // (e.g. Disconnect() called immediately after Connect()) cannot be overwritten.
+            CentrifugeClientState prevState;
+            lock (_stateChangeLock)
+            {
+                if (_state != CentrifugeClientState.Disconnected) return;
+                _reconnectAttempts = 0;
+                prevState = SetState(CentrifugeClientState.Connecting);
+            }
+            if (prevState != CentrifugeClientState.Connecting)
+                StateChanged?.Invoke(this, new CentrifugeStateEventArgs(prevState, CentrifugeClientState.Connecting));
             Connecting?.Invoke(this, new CentrifugeConnectingEventArgs(CentrifugeConnectingCodes.ConnectCalled, "connect called"));
 
             _ = Task.Run(async () =>
@@ -972,21 +998,19 @@ namespace Centrifugal.Centrifuge
                 {
                     // Unauthorized exception should stop connection attempts permanently
                     _logger?.LogDebug($"Caught CentrifugeUnauthorizedException in StartConnecting: {ex.Message}");
-                    await SetDisconnectedAsync(CentrifugeDisconnectedCodes.Unauthorized, "unauthorized", false).ConfigureAwait(false);
+                    await SetDisconnectedAsync(CentrifugeDisconnectedCodes.Unauthorized, "unauthorized").ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
-                    // If using multi-transport fallback and transport failed before opening,
-                    // try the next transport in the list
-                    if (_transportEndpoints != null && !_transportWasOpen)
+                    lock (_stateChangeLock)
                     {
-                        _currentTransportIndex++;
-                        if (_currentTransportIndex >= _transportEndpoints.Count)
+                        if (_transportEndpoints != null && !_transportWasOpen)
                         {
-                            _currentTransportIndex = 0;
+                            _currentTransportIndex++;
+                            if (_currentTransportIndex >= _transportEndpoints.Count)
+                                _currentTransportIndex = 0;
                         }
                     }
-
                     OnError("transport", ex);
                     await ScheduleReconnectAsync().ConfigureAwait(false);
                 }
@@ -995,7 +1019,14 @@ namespace Centrifugal.Centrifuge
 
         private async Task StartConnectingAsync(int code, string reason)
         {
-            SetState(CentrifugeClientState.Connecting);
+            CentrifugeClientState prevState;
+            lock (_stateChangeLock)
+            {
+                if (_state == CentrifugeClientState.Disconnected) return;
+                prevState = SetState(CentrifugeClientState.Connecting);
+            }
+            if (prevState != CentrifugeClientState.Connecting)
+                StateChanged?.Invoke(this, new CentrifugeStateEventArgs(prevState, CentrifugeClientState.Connecting));
             Connecting?.Invoke(this, new CentrifugeConnectingEventArgs(code, reason));
 
             try
@@ -1006,21 +1037,19 @@ namespace Centrifugal.Centrifuge
             {
                 // Unauthorized exception should stop connection attempts permanently
                 _logger?.LogDebug($"Caught CentrifugeUnauthorizedException in StartConnectingAsync: {ex.Message}");
-                await SetDisconnectedAsync(CentrifugeDisconnectedCodes.Unauthorized, "unauthorized", false).ConfigureAwait(false);
+                await SetDisconnectedAsync(CentrifugeDisconnectedCodes.Unauthorized, "unauthorized").ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                // If using multi-transport fallback and transport failed before opening,
-                // try the next transport in the list
-                if (_transportEndpoints != null && !_transportWasOpen)
+                lock (_stateChangeLock)
                 {
-                    _currentTransportIndex++;
-                    if (_currentTransportIndex >= _transportEndpoints.Count)
+                    if (_transportEndpoints != null && !_transportWasOpen)
                     {
-                        _currentTransportIndex = 0;
+                        _currentTransportIndex++;
+                        if (_currentTransportIndex >= _transportEndpoints.Count)
+                            _currentTransportIndex = 0;
                     }
                 }
-
                 OnError("transport", ex);
                 await ScheduleReconnectAsync().ConfigureAwait(false);
             }
@@ -1028,15 +1057,21 @@ namespace Centrifugal.Centrifuge
 
         private async Task CreateTransportAsync()
         {
-            // Unsubscribe from old transport events before disposing to prevent race conditions
-            if (_transport != null)
+            // Defensively clean up any lingering transport (CleanupTransportAsync should have nulled it,
+            // but guard here in case this path is reached via an unexpected code path).
+            ITransport? staleTransport;
+            lock (_stateChangeLock)
             {
-                _transport.Opened -= OnTransportOpened;
-                _transport.MessageReceived -= OnTransportMessage;
-                _transport.Closed -= OnTransportClosed;
-                _transport.Error -= OnTransportError;
-                _transport.Dispose();
-                _transport = null;
+                staleTransport = _transport;
+                if (staleTransport != null) _transport = null;
+            }
+            if (staleTransport != null)
+            {
+                staleTransport.Opened -= OnTransportOpened;
+                staleTransport.MessageReceived -= OnTransportMessage;
+                staleTransport.Closed -= OnTransportClosed;
+                staleTransport.Error -= OnTransportError;
+                staleTransport.Dispose();
             }
 
             ITransport transport;
@@ -1045,36 +1080,42 @@ namespace Centrifugal.Centrifuge
             if (_transportEndpoints != null)
             {
                 // Move to next transport if we've exceeded the list
-                if (_currentTransportIndex >= _transportEndpoints.Count)
+                lock (_stateChangeLock)
                 {
-                    _currentTransportIndex = 0;
+                    if (_currentTransportIndex >= _transportEndpoints.Count)
+                        _currentTransportIndex = 0;
                 }
 
                 // Try transports until we find a supported one
                 int attempts = 0;
                 while (attempts < _transportEndpoints.Count)
                 {
-                    var transportConfig = _transportEndpoints[_currentTransportIndex];
+                    int idx;
+                    lock (_stateChangeLock) { idx = _currentTransportIndex; }
+                    var transportConfig = _transportEndpoints[idx];
 
                     try
                     {
                         transport = CreateTransport(transportConfig.Transport, transportConfig.Endpoint);
-                        _transport = transport;
+                        lock (_stateChangeLock) { _transport = transport; }
                         break;
                     }
                     catch (CentrifugeConfigurationException)
                     {
                         // Unsupported transport, try next one
-                        _currentTransportIndex++;
-                        if (_currentTransportIndex >= _transportEndpoints.Count)
+                        lock (_stateChangeLock)
                         {
-                            _currentTransportIndex = 0;
+                            _currentTransportIndex++;
+                            if (_currentTransportIndex >= _transportEndpoints.Count)
+                                _currentTransportIndex = 0;
                         }
                         attempts++;
                     }
                 }
 
-                if (_transport == null)
+                ITransport? currentTransport;
+                lock (_stateChangeLock) { currentTransport = _transport; }
+                if (currentTransport == null)
                 {
                     throw new CentrifugeConfigurationException("No supported transport found in the transport endpoints list");
                 }
@@ -1088,14 +1129,14 @@ namespace Centrifugal.Centrifuge
                 {
                     // Use the same logic as CreateTransport to properly select browser vs native transport
                     transport = CreateTransport(CentrifugeTransportType.WebSocket, _endpoint);
-                    _transport = transport;
+                    lock (_stateChangeLock) { _transport = transport; }
                 }
                 else if (_endpoint.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
                          _endpoint.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
                 {
                     // Support HTTP streaming endpoint as well
                     transport = CreateTransport(CentrifugeTransportType.HttpStream, _endpoint);
-                    _transport = transport;
+                    lock (_stateChangeLock) { _transport = transport; }
                 }
                 else
                 {
@@ -1107,15 +1148,17 @@ namespace Centrifugal.Centrifuge
                 throw new CentrifugeConfigurationException("No endpoint configured");
             }
 
-            _transport.Opened += OnTransportOpened;
-            _transport.MessageReceived += OnTransportMessage;
-            _transport.Closed += OnTransportClosed;
-            _transport.Error += OnTransportError;
+            ITransport localTransport;
+            lock (_stateChangeLock) { localTransport = _transport!; }
+            localTransport.Opened += OnTransportOpened;
+            localTransport.MessageReceived += OnTransportMessage;
+            localTransport.Closed += OnTransportClosed;
+            localTransport.Error += OnTransportError;
 
             // For emulation transports, build connect command and send it during OpenAsync
             byte[]? initialData = null;
             TaskCompletionSource<Reply>? connectTcs = null;
-            if (_transport.UsesEmulation)
+            if (localTransport.UsesEmulation)
             {
                 // Build and store the connect command for later use in SendConnectCommandAsync
                 _pendingConnectCommand = await BuildConnectCommandObjectAsync().ConfigureAwait(false);
@@ -1123,18 +1166,40 @@ namespace Centrifugal.Centrifuge
 
                 // Register the pending call BEFORE opening the transport to avoid race condition
                 // where reply arrives before registration
-                connectTcs = new TaskCompletionSource<Reply>();
+                connectTcs = new TaskCompletionSource<Reply>(TaskCreationOptions.RunContinuationsAsynchronously);
                 _pendingCalls[_pendingConnectCommand.Id] = connectTcs;
+            }
+
+            // State check before opening: Disconnect() may have run while BuildConnectCommandObjectAsync
+            // was executing (no GetToken await means no prior re-check for already-set tokens).
+            lock (_stateChangeLock)
+            {
+                if (_state == CentrifugeClientState.Disconnected)
+                {
+                    if (_pendingConnectCommand != null)
+                        _pendingCalls.TryRemove(_pendingConnectCommand.Id, out _);
+                    localTransport.Opened -= OnTransportOpened;
+                    localTransport.MessageReceived -= OnTransportMessage;
+                    localTransport.Closed -= OnTransportClosed;
+                    localTransport.Error -= OnTransportError;
+                    return;
+                }
             }
 
             try
             {
-                await _transport.OpenAsync(initialData: initialData).ConfigureAwait(false);
+                await localTransport.OpenAsync(initialData: initialData).ConfigureAwait(false);
             }
             catch
             {
-                // OpenAsync failed before SendConnectCommandAsync's finally could clean up the
-                // pre-registered emulation entry — remove it here to avoid leaking _pendingCalls slots.
+                // Unregister event handlers so that async JS callbacks (onclose etc.) arriving
+                // after the failure do not fire OnTransportClosed and start a second reconnect.
+                localTransport.Opened -= OnTransportOpened;
+                localTransport.MessageReceived -= OnTransportMessage;
+                localTransport.Closed -= OnTransportClosed;
+                localTransport.Error -= OnTransportError;
+
+                // Remove the pre-registered emulation pending call to avoid leaking _pendingCalls slots.
                 if (_pendingConnectCommand != null)
                 {
                     _pendingCalls.TryRemove(_pendingConnectCommand.Id, out _);
@@ -1188,10 +1253,10 @@ namespace Centrifugal.Centrifuge
         {
             _logger?.LogDebug("OnTransportOpened called");
             // Defensive check: don't process events if client is disposed
-            if (_disposed) return;
+            if (_disposed != 0) return;
 
             // Mark that at least one transport successfully opened
-            _transportWasOpen = true;
+            lock (_stateChangeLock) { _transportWasOpen = true; }
 
             try
             {
@@ -1202,39 +1267,71 @@ namespace Centrifugal.Centrifuge
             catch (CentrifugeTimeoutException ex)
             {
                 _logger?.LogDebug($"Connect timeout: {ex.Message}");
-                // Connect timeout should trigger reconnect, not permanent disconnect
                 OnError("connect", new CentrifugeException(CentrifugeErrorCodes.Timeout, "connect timeout", true));
-                _transport?.Dispose();
-                _transport = null;
+                ITransport? t1;
+                lock (_stateChangeLock)
+                {
+                    t1 = _transport;
+                    if (t1 != null)
+                    {
+                        t1.Opened -= OnTransportOpened;
+                        t1.MessageReceived -= OnTransportMessage;
+                        t1.Closed -= OnTransportClosed;
+                        t1.Error -= OnTransportError;
+                        _transport = null;
+                    }
+                }
+                t1?.Dispose();
                 await ScheduleReconnectAsync().ConfigureAwait(false);
             }
             catch (CentrifugeException ex)
             {
                 _logger?.LogDebug($"CentrifugeException in connect: Code={ex.Code}, Message={ex.Message}, Temporary={ex.Temporary}");
-                // Error code 109 (token expired) or temporary errors should trigger reconnect
                 if (ex.Code == 109 || ex.Code < 100 || ex.Temporary)
                 {
                     _logger?.LogDebug("Triggering reconnect due to temporary error");
                     OnError("connect", ex);
-                    _transport?.Dispose();
-                    _transport = null;
+                    ITransport? t2;
+                    lock (_stateChangeLock)
+                    {
+                        t2 = _transport;
+                        if (t2 != null)
+                        {
+                            t2.Opened -= OnTransportOpened;
+                            t2.MessageReceived -= OnTransportMessage;
+                            t2.Closed -= OnTransportClosed;
+                            t2.Error -= OnTransportError;
+                            _transport = null;
+                        }
+                    }
+                    t2?.Dispose();
                     await ScheduleReconnectAsync().ConfigureAwait(false);
                 }
                 else
                 {
                     _logger?.LogDebug("Permanent error, disconnecting");
-                    // Permanent error - disconnect
                     OnError("connect", ex);
-                    await SetDisconnectedAsync(ex.Code, ex.Message, false).ConfigureAwait(false);
+                    await SetDisconnectedAsync(ex.Code, ex.Message).ConfigureAwait(false);
                 }
             }
             catch (Exception ex)
             {
                 _logger?.LogDebug($"General exception in connect: {ex.GetType().Name}: {ex.Message}");
-                // General exceptions during connect should trigger reconnect (e.g., GetToken errors)
                 OnError("connect", ex);
-                _transport?.Dispose();
-                _transport = null;
+                ITransport? t3;
+                lock (_stateChangeLock)
+                {
+                    t3 = _transport;
+                    if (t3 != null)
+                    {
+                        t3.Opened -= OnTransportOpened;
+                        t3.MessageReceived -= OnTransportMessage;
+                        t3.Closed -= OnTransportClosed;
+                        t3.Error -= OnTransportError;
+                        _transport = null;
+                    }
+                }
+                t3?.Dispose();
                 await ScheduleReconnectAsync().ConfigureAwait(false);
             }
         }
@@ -1242,19 +1339,24 @@ namespace Centrifugal.Centrifuge
         private async Task<Command> BuildConnectCommandObjectAsync()
         {
             string? token;
+            bool needsRefresh;
             lock (_stateChangeLock)
             {
                 token = _options.Token;
+                needsRefresh = _refreshRequired;
             }
 
             // If refresh is required or token is empty, try to get a new token
-            if ((string.IsNullOrEmpty(token) || _refreshRequired) && _options.GetToken != null)
+            if ((string.IsNullOrEmpty(token) || needsRefresh) && _options.GetToken != null)
             {
                 try
                 {
                     token = await _options.GetToken().ConfigureAwait(false);
+                    // State may have changed while we awaited GetToken (e.g. Disconnect called)
                     lock (_stateChangeLock)
                     {
+                        if (_state != CentrifugeClientState.Connecting)
+                            throw new OperationCanceledException("client is no longer connecting");
                         _options.Token = token;
                     }
                 }
@@ -1322,9 +1424,12 @@ namespace Centrifugal.Centrifuge
 
         private async Task SendConnectCommandAsync()
         {
-            _logger?.LogDebug($"SendConnectCommandAsync - UsesEmulation: {_transport!.UsesEmulation}");
+            ITransport? transport;
+            lock (_stateChangeLock) { transport = _transport; }
+            if (transport == null) return;
+            _logger?.LogDebug($"SendConnectCommandAsync - UsesEmulation: {transport.UsesEmulation}");
             // For emulation transports, reuse the command that was already sent during OpenAsync
-            if (_transport!.UsesEmulation && _pendingConnectCommand != null)
+            if (transport.UsesEmulation && _pendingConnectCommand != null)
             {
                 var pendingCmd = _pendingConnectCommand;
                 _pendingConnectCommand = null; // Clear it so it's not reused on reconnect
@@ -1351,8 +1456,11 @@ namespace Centrifugal.Centrifuge
 
                 if (connectReply.Error != null)
                 {
-                    var error = new CentrifugeException((int)connectReply.Error.Code, connectReply.Error.Message, connectReply.Error.Temporary);
-                    throw error;
+                    if (connectReply.Error.Code == 109)
+                    {
+                        lock (_stateChangeLock) { _refreshRequired = true; }
+                    }
+                    throw new CentrifugeException((int)connectReply.Error.Code, connectReply.Error.Message, connectReply.Error.Temporary);
                 }
 
                 HandleConnectReply(connectReply.Connect);
@@ -1360,25 +1468,29 @@ namespace Centrifugal.Centrifuge
             }
 
             string? token;
+            bool needsRefreshConnect;
             lock (_stateChangeLock)
             {
                 token = _options.Token;
+                needsRefreshConnect = _refreshRequired;
             }
 
             // If refresh is required or token is empty, try to get a new token
-            if ((string.IsNullOrEmpty(token) || _refreshRequired) && _options.GetToken != null)
+            if ((string.IsNullOrEmpty(token) || needsRefreshConnect) && _options.GetToken != null)
             {
                 try
                 {
                     token = await _options.GetToken().ConfigureAwait(false);
+                    // State may have changed while we awaited GetToken (e.g. Disconnect called)
                     lock (_stateChangeLock)
                     {
+                        if (_state != CentrifugeClientState.Connecting) return;
                         _options.Token = token;
                     }
                 }
                 catch (CentrifugeUnauthorizedException)
                 {
-                    await SetDisconnectedAsync(CentrifugeDisconnectedCodes.Unauthorized, "unauthorized", false).ConfigureAwait(false);
+                    await SetDisconnectedAsync(CentrifugeDisconnectedCodes.Unauthorized, "unauthorized").ConfigureAwait(false);
                     return;
                 }
             }
@@ -1447,7 +1559,7 @@ namespace Centrifugal.Centrifuge
                 // Error code 109 means token expired - mark for refresh on next connect
                 if (reply.Error.Code == 109)
                 {
-                    _refreshRequired = true;
+                    lock (_stateChangeLock) { _refreshRequired = true; }
                 }
 
                 throw error;
@@ -1458,54 +1570,48 @@ namespace Centrifugal.Centrifuge
 
         private void HandleConnectReply(ConnectResult connectResult)
         {
-            // Check if this is a reconnection (we had a client ID from a previous connection)
-            bool isReconnect = !string.IsNullOrEmpty(_clientId);
-
-            _clientId = connectResult.Client;
-            _session = connectResult.Session;
-            _node = connectResult.Node;
-
-            // Hold _stateChangeLock across the state transition and ResolvePromises so a
-            // ReadyAsync caller can't observe Connecting, miss our resolve, and then register
-            // a tcs that nobody will complete.
+            // Hold _stateChangeLock across all field writes, the state transition, and
+            // ResolvePromises so a ReadyAsync caller can't observe Connecting, miss our
+            // resolve, and then register a tcs that nobody will complete.
+            string transportName;
+            CentrifugeClientState prevState;
             lock (_stateChangeLock)
             {
-                SetState(CentrifugeClientState.Connected);
+                _clientId = connectResult.Client;
+                _session = connectResult.Session;
+                _node = connectResult.Node;
+                prevState = SetState(CentrifugeClientState.Connected);
                 _transportIsOpen = true;
                 ResolvePromises();
+
+                _reconnectAttempts = 0;
+                ClearRefreshTimer();
+                _refreshAttempts = 0;
+                _refreshRequired = false;
+                if (connectResult.Expires) ScheduleConnectionRefresh(connectResult.Ttl);
+
+                if (connectResult.Ping > 0)
+                {
+                    _serverPingInterval = connectResult.Ping;
+                    _sendPong = connectResult.Pong;
+                    StartPingTimer(connectResult.Ping);
+                }
+                else
+                {
+                    _serverPingInterval = 0;
+                    _sendPong = false;
+                }
+
+                transportName = _transport?.Name ?? "unknown";
             }
 
+            if (prevState != CentrifugeClientState.Connected)
+                StateChanged?.Invoke(this, new CentrifugeStateEventArgs(prevState, CentrifugeClientState.Connected));
             Connected?.Invoke(this, new CentrifugeConnectedEventArgs(
                 connectResult.Client,
-                _transport?.Name ?? "unknown",
+                transportName,
                 connectResult.Data.ToByteArray()
             ));
-
-            _reconnectAttempts = 0;
-
-            // Clear refresh timer and reset attempts
-            ClearRefreshTimer();
-            _refreshAttempts = 0;
-            _refreshRequired = false;
-
-            // Schedule token refresh if token expires
-            if (connectResult.Expires)
-            {
-                ScheduleConnectionRefresh(connectResult.Ttl);
-            }
-
-            // Start ping timer if server sends pings
-            if (connectResult.Ping > 0)
-            {
-                _serverPingInterval = connectResult.Ping;
-                _sendPong = connectResult.Pong;
-                StartPingTimer(connectResult.Ping);
-            }
-            else
-            {
-                _serverPingInterval = 0;
-                _sendPong = false;
-            }
 
             // Process server-side subscriptions
             ProcessServerSubscriptions(connectResult.Subs);
@@ -1513,6 +1619,12 @@ namespace Centrifugal.Centrifuge
             // Send subscribe commands for all subscriptions in Subscribing state
             // This handles both first connect and reconnect scenarios
             SendSubscribeCommands();
+
+            // Flush any commands queued while we were Connecting (e.g. RpcAsync called
+            // from a Connecting event handler). Without this kick, those commands sit in
+            // _commandBatch until another Schedule/Flush trigger, potentially hanging up
+            // to the per-command timeout if there are no subscriptions to drive a flush.
+            _ = Task.Run(async () => await FlushCommandBatchAsync().ConfigureAwait(false));
         }
 
         private void SendSubscribeCommands()
@@ -1537,15 +1649,15 @@ namespace Centrifugal.Centrifuge
 
         private async Task SendSubscribeCommandsAsync()
         {
-            // Check client state before processing
-            if (_state != CentrifugeClientState.Connected || !_transportIsOpen)
+            lock (_stateChangeLock)
             {
-                return;
+                if (_state != CentrifugeClientState.Connected || !_transportIsOpen) return;
             }
 
-            // Start all subscribe commands concurrently so they can be batched together
+            // Start all subscribe commands concurrently so they can be batched together.
+            // No .Where(sub.State) filter — SendSubscribeIfNeededAsync does the authoritative
+            // locked state check internally; a bare non-volatile read here would be stale anyway.
             var subscribeTasks = _subscriptions.Values
-                .Where(sub => sub.State == CentrifugeSubscriptionState.Subscribing)
                 .Select(sub => sub.SendSubscribeIfNeededAsync())
                 .ToList();
 
@@ -1558,12 +1670,14 @@ namespace Centrifugal.Centrifuge
         private void OnTransportMessage(object? sender, byte[] data)
         {
             // Defensive check: don't process events if client is disposed
-            if (_disposed) return;
+            if (_disposed != 0) return;
 
             try
             {
                 // Reset ping timer on any message received
-                if (_serverPingInterval > 0)
+                uint serverPingInterval;
+                lock (_stateChangeLock) { serverPingInterval = _serverPingInterval; }
+                if (serverPingInterval > 0)
                 {
                     ResetPingTimer();
                 }
@@ -1613,6 +1727,23 @@ namespace Centrifugal.Centrifuge
                     // Server-side subscription
                     var pub = CreatePublicationArgs(push.Channel, push.Pub);
                     Publication?.Invoke(this, pub);
+
+                    if (push.Pub.Offset > 0)
+                    {
+                        lock (_stateChangeLock)
+                        {
+                            if (_serverSubscriptions.TryGetValue(push.Channel, out var existing) &&
+                                push.Pub.Offset > existing.Offset)
+                            {
+                                _serverSubscriptions[push.Channel] = new ServerSubscription
+                                {
+                                    Offset = push.Pub.Offset,
+                                    Epoch = existing.Epoch,
+                                    Recoverable = existing.Recoverable
+                                };
+                            }
+                        }
+                    }
                 }
             }
             else if (push.Join != null)
@@ -1691,22 +1822,40 @@ namespace Centrifugal.Centrifuge
 
             if (reconnect)
             {
-                // Disconnect with reconnect
                 _logger?.LogDebug($"HandleDisconnectPush - calling HandleTransportClosedAsync for reconnect");
+                // Pre-unregister all transport handlers: the server closes the transport after sending
+                // the disconnect push. Without detaching Closed, OnTransportClosed would fire and trigger
+                // a second HandleTransportClosedAsync. Without detaching MessageReceived/Error/Opened,
+                // any frame already buffered between the disconnect push and the close would still
+                // dispatch user-facing events for a connection we've decided is dead.
+                // Capture transport under _stateChangeLock; unsubscribe outside the lock so a custom
+                // event accessor implementation can never block the state machine.
+                ITransport? transport;
+                lock (_stateChangeLock)
+                {
+                    transport = _transport;
+                }
+                if (transport != null)
+                {
+                    transport.Closed -= OnTransportClosed;
+                    transport.MessageReceived -= OnTransportMessage;
+                    transport.Error -= OnTransportError;
+                    transport.Opened -= OnTransportOpened;
+                }
                 _ = HandleTransportClosedAsync(new TransportClosedEventArgs(code: code, reason: disconnect.Reason));
             }
             else
             {
                 // Permanent disconnect
                 _logger?.LogDebug($"HandleDisconnectPush - calling SetDisconnectedAsync for permanent disconnect");
-                _ = SetDisconnectedAsync(code, disconnect.Reason, false);
+                _ = SetDisconnectedAsync(code, disconnect.Reason);
             }
         }
 
         private void OnTransportClosed(object? sender, TransportClosedEventArgs e)
         {
             // Defensive check: don't process events if client is disposed
-            if (_disposed) return;
+            if (_disposed != 0) return;
 
             _logger?.LogDebug($"OnTransportClosed - code: {e.Code}, reason: '{e.Reason}'");
             _ = HandleTransportClosedAsync(e);
@@ -1717,18 +1866,13 @@ namespace Centrifugal.Centrifuge
             _logger?.LogDebug($"HandleTransportClosedAsync - state: {_state}, code: {e.Code}, reason: '{e.Reason}'");
 
             // Don't process if already disconnected
-            if (_state == CentrifugeClientState.Disconnected)
+            lock (_stateChangeLock)
             {
-                _logger?.LogDebug($"HandleTransportClosedAsync - skipping (state is {_state})");
-                return;
-            }
-
-            // If already in Connecting state, cancel any pending reconnect and restart
-            // This handles the case where transport closes during connection (e.g., server sends disconnect while connecting)
-            if (_state == CentrifugeClientState.Connecting)
-            {
-                _logger?.LogDebug($"HandleTransportClosedAsync - transport closed while connecting, restarting reconnect logic");
-                _reconnectCts?.Cancel();
+                if (_state == CentrifugeClientState.Disconnected)
+                {
+                    _logger?.LogDebug("HandleTransportClosedAsync - skipping (already disconnected)");
+                    return;
+                }
             }
 
             // Determine if we should reconnect based on close code
@@ -1765,24 +1909,38 @@ namespace Centrifugal.Centrifuge
             if (!shouldReconnect)
             {
                 // Permanent disconnect
-                await SetDisconnectedAsync(code, reason, false).ConfigureAwait(false);
+                await SetDisconnectedAsync(code, reason).ConfigureAwait(false);
                 return;
             }
 
             // If using multi-transport fallback and transport closed before opening,
             // try the next transport in the list
-            if (_transportEndpoints != null && !_transportWasOpen)
+            lock (_stateChangeLock)
             {
-                _currentTransportIndex++;
-                if (_currentTransportIndex >= _transportEndpoints.Count)
+                if (_transportEndpoints != null && !_transportWasOpen)
                 {
-                    _currentTransportIndex = 0;
+                    _currentTransportIndex++;
+                    if (_currentTransportIndex >= _transportEndpoints.Count)
+                        _currentTransportIndex = 0;
                 }
             }
 
-            // Set state to Connecting FIRST to prevent duplicate processing
-            // This must happen before CleanupTransportAsync to block concurrent HandleTransportClosedAsync calls
-            SetState(CentrifugeClientState.Connecting);
+            // Transition to Connecting under _stateChangeLock so it can't race with a
+            // concurrent SetDisconnectedAsync (e.g. user calls Disconnect() at the same time).
+            // Also cancel any in-flight reconnect timer atomically with the state change.
+            CentrifugeClientState prevState;
+            lock (_stateChangeLock)
+            {
+                // Re-check: SetDisconnectedAsync may have won the race and set Disconnected already
+                if (_state == CentrifugeClientState.Disconnected)
+                {
+                    _logger?.LogDebug("HandleTransportClosedAsync - aborting reconnect, state is already Disconnected");
+                    return;
+                }
+
+                _reconnectCts?.Cancel();
+                prevState = SetState(CentrifugeClientState.Connecting);
+            }
 
             // Move all subscribed subscriptions to subscribing state BEFORE emitting connecting event
             foreach (var sub in _subscriptions.Values)
@@ -1790,7 +1948,8 @@ namespace Centrifugal.Centrifuge
                 sub.MoveToSubscribing(CentrifugeSubscribingCodes.TransportClosed, "transport closed");
             }
 
-            // Use the actual disconnect code and reason from the server (not hardcoded TransportClosed)
+            if (prevState != CentrifugeClientState.Connecting)
+                StateChanged?.Invoke(this, new CentrifugeStateEventArgs(prevState, CentrifugeClientState.Connecting));
             _logger?.LogDebug($"Firing Connecting event with code: {code}, reason: '{reason}'");
             Connecting?.Invoke(this, new CentrifugeConnectingEventArgs(code, reason));
 
@@ -1804,7 +1963,7 @@ namespace Centrifugal.Centrifuge
         private void OnTransportError(object? sender, Exception e)
         {
             // Defensive check: don't process events if client is disposed
-            if (_disposed) return;
+            if (_disposed != 0) return;
 
             OnError("transport", e);
         }
@@ -1812,32 +1971,48 @@ namespace Centrifugal.Centrifuge
         internal async Task HandleSubscribeTimeoutAsync()
         {
             // Subscribe timeout triggers client disconnect with reconnect
-            if (_state == CentrifugeClientState.Disconnected)
+            CentrifugeClientState prevState;
+            lock (_stateChangeLock)
             {
-                return;
+                if (_state == CentrifugeClientState.Disconnected) return;
+                _reconnectCts?.Cancel();
+                prevState = SetState(CentrifugeClientState.Connecting);
             }
 
-            await StartConnectingAsync(CentrifugeConnectingCodes.SubscribeTimeout, "subscribe timeout").ConfigureAwait(false);
+            foreach (var sub in _subscriptions.Values)
+            {
+                sub.MoveToSubscribing(CentrifugeSubscribingCodes.TransportClosed, "transport closed");
+            }
 
-            // Properly clean up transport before reconnecting
+            if (prevState != CentrifugeClientState.Connecting)
+                StateChanged?.Invoke(this, new CentrifugeStateEventArgs(prevState, CentrifugeClientState.Connecting));
+            Connecting?.Invoke(this, new CentrifugeConnectingEventArgs(CentrifugeConnectingCodes.SubscribeTimeout, "subscribe timeout"));
+
             await CleanupTransportAsync().ConfigureAwait(false);
-
             await ScheduleReconnectAsync().ConfigureAwait(false);
         }
 
         internal async Task HandleUnsubscribeErrorAsync()
         {
             // Unsubscribe error triggers client disconnect with reconnect (matching centrifuge-js behavior)
-            if (_state == CentrifugeClientState.Disconnected)
+            CentrifugeClientState prevState;
+            lock (_stateChangeLock)
             {
-                return;
+                if (_state == CentrifugeClientState.Disconnected) return;
+                _reconnectCts?.Cancel();
+                prevState = SetState(CentrifugeClientState.Connecting);
             }
 
-            await StartConnectingAsync(CentrifugeConnectingCodes.UnsubscribeError, "unsubscribe error").ConfigureAwait(false);
+            foreach (var sub in _subscriptions.Values)
+            {
+                sub.MoveToSubscribing(CentrifugeSubscribingCodes.TransportClosed, "transport closed");
+            }
 
-            // Properly clean up transport before reconnecting
+            if (prevState != CentrifugeClientState.Connecting)
+                StateChanged?.Invoke(this, new CentrifugeStateEventArgs(prevState, CentrifugeClientState.Connecting));
+            Connecting?.Invoke(this, new CentrifugeConnectingEventArgs(CentrifugeConnectingCodes.UnsubscribeError, "unsubscribe error"));
+
             await CleanupTransportAsync().ConfigureAwait(false);
-
             await ScheduleReconnectAsync().ConfigureAwait(false);
         }
 
@@ -1847,91 +2022,131 @@ namespace Centrifugal.Centrifuge
         /// </summary>
         private async Task CleanupTransportAsync()
         {
-            if (_transport == null)
+            ITransport? transport;
+            Timer? pingTimer;
+            List<TaskCompletionSource<Reply>>? pendingToFail;
+            lock (_stateChangeLock)
             {
-                return;
-            }
-
-            try
-            {
-                // Stop ping timer
-                _pingTimer?.Dispose();
+                transport = _transport;
+                _transport = null;
+                pingTimer = _pingTimer;
                 _pingTimer = null;
                 _serverPingInterval = 0;
                 _sendPong = false;
+                _transportIsOpen = false;
+                // Atomically snapshot and clear pending calls while _transport is null.
+                // SendCommandAsync guards on (_transport != null) under this same lock, so after
+                // this block no new entries can be added — all existing ones are captured here.
+                if (transport != null)
+                {
+                    pendingToFail = new List<TaskCompletionSource<Reply>>(_pendingCalls.Values);
+                    _pendingCalls.Clear();
+                }
+                else
+                {
+                    pendingToFail = null;
+                }
+            }
 
-                // Clear inflight requests
-                ClearInflightRequests();
+            pingTimer?.Dispose();
+
+            // Complete captured pending calls outside the lock (TCS continuations may be synchronous).
+            if (pendingToFail != null)
+            {
+                var connClosedEx = new CentrifugeException(CentrifugeErrorCodes.ConnectionClosed, "connection closed", false);
+                foreach (var tcs in pendingToFail) tcs.TrySetException(connClosedEx);
+            }
+
+            if (transport == null) return;
+
+            try
+            {
+                // Clear pending batch commands
+                lock (_commandBatchLock)
+                {
+                    _commandBatch.Clear();
+                    _commandBatchSize = 0;
+                    _commandBatchPending = false;
+                    _commandBatchTimer?.Dispose();
+                    _commandBatchTimer = null;
+                }
 
                 // Unsubscribe from transport events BEFORE closing to prevent race conditions
-                _transport.Opened -= OnTransportOpened;
-                _transport.MessageReceived -= OnTransportMessage;
-                _transport.Closed -= OnTransportClosed;
-                _transport.Error -= OnTransportError;
+                transport.Opened -= OnTransportOpened;
+                transport.MessageReceived -= OnTransportMessage;
+                transport.Closed -= OnTransportClosed;
+                transport.Error -= OnTransportError;
 
                 // Close and dispose transport
-                await _transport.CloseAsync().ConfigureAwait(false);
-                _transport.Dispose();
-                _transport = null;
+                await transport.CloseAsync().ConfigureAwait(false);
+                transport.Dispose();
             }
             catch
             {
-                // Ignore cleanup errors, but ensure transport is set to null
-                _transport = null;
+                // Ignore cleanup errors
             }
         }
 
         private async Task ScheduleReconnectAsync()
         {
-            if (_state == CentrifugeClientState.Disconnected)
+            CancellationToken reconnectToken;
+            int currentAttempts;
+            lock (_stateChangeLock)
             {
-                return;
+                if (_state == CentrifugeClientState.Disconnected) return;
+
+                var oldCts = _reconnectCts;
+                _reconnectCts = new CancellationTokenSource();
+                oldCts?.Cancel();
+                oldCts?.Dispose();
+                reconnectToken = _reconnectCts.Token;
+                currentAttempts = _reconnectAttempts++;
             }
-
-            var oldReconnectCts = _reconnectCts;
-            _reconnectCts = new CancellationTokenSource();
-            oldReconnectCts?.Cancel();
-            oldReconnectCts?.Dispose();
-
             int delay = Utilities.CalculateBackoff(
-                _reconnectAttempts++,
+                currentAttempts,
                 _options.MinReconnectDelay,
                 _options.MaxReconnectDelay
             );
 
             try
             {
-                await Task.Delay(delay, _reconnectCts.Token).ConfigureAwait(false);
+                await Task.Delay(delay, reconnectToken).ConfigureAwait(false);
+                lock (_stateChangeLock)
+                {
+                    if (_state == CentrifugeClientState.Disconnected) return;
+                }
                 await CreateTransportAsync().ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
                 // Reconnect was cancelled
             }
+            catch (ObjectDisposedException)
+            {
+                // _reconnectCts was disposed by Dispose()/DisposeAsync() between our
+                // capture above and Task.Delay's registration — treat as cancellation.
+            }
             catch (Exception ex)
             {
-                // CreateTransportAsync failed - report error and schedule next reconnection attempt
-                // If using multi-transport fallback and transport failed before opening,
-                // try the next transport in the list
-                if (_transportEndpoints != null && !_transportWasOpen)
+                lock (_stateChangeLock)
                 {
-                    _currentTransportIndex++;
-                    if (_currentTransportIndex >= _transportEndpoints.Count)
+                    if (_transportEndpoints != null && !_transportWasOpen)
                     {
-                        _currentTransportIndex = 0;
+                        _currentTransportIndex++;
+                        if (_currentTransportIndex >= _transportEndpoints.Count)
+                            _currentTransportIndex = 0;
                     }
                 }
-
                 OnError("transport", ex);
-
-                // Schedule next reconnection attempt
                 await ScheduleReconnectAsync().ConfigureAwait(false);
             }
         }
 
-        private async Task SetDisconnectedAsync(int code, string reason, bool shouldReconnect)
+        private async Task SetDisconnectedAsync(int code, string reason)
         {
-            // Change state synchronously first
+            // Change state synchronously first; fire events OUTSIDE the lock to avoid
+            // deadlocking if a user's synchronous event handler calls back into the SDK.
+            CentrifugeClientState prevState;
             lock (_stateChangeLock)
             {
                 if (_state == CentrifugeClientState.Disconnected)
@@ -1939,22 +2154,19 @@ namespace Centrifugal.Centrifuge
                     return;
                 }
 
-                if (shouldReconnect)
-                {
-                    SetState(CentrifugeClientState.Connecting);
-                    Connecting?.Invoke(this, new CentrifugeConnectingEventArgs(code, reason));
-                }
-                else
-                {
-                    SetState(CentrifugeClientState.Disconnected);
-                    Disconnected?.Invoke(this, new CentrifugeDisconnectedEventArgs(code, reason));
-
-                    // Reject ready promises when disconnecting
-                    RejectPromises(new CentrifugeException(CentrifugeErrorCodes.ClientDisconnected, "client disconnected"));
-                }
+                prevState = SetState(CentrifugeClientState.Disconnected);
+                RejectPromises(new CentrifugeException(CentrifugeErrorCodes.ClientDisconnected, "client disconnected"));
 
                 _transportIsOpen = false;
+                _transportWasOpen = false;
+                try { _reconnectCts?.Cancel(); } catch (ObjectDisposedException) { }
+                _reconnectCts?.Dispose();
+                _reconnectCts = null;
             }
+
+            if (prevState != CentrifugeClientState.Disconnected)
+                StateChanged?.Invoke(this, new CentrifugeStateEventArgs(prevState, CentrifugeClientState.Disconnected));
+            Disconnected?.Invoke(this, new CentrifugeDisconnectedEventArgs(code, reason));
 
             // Now do async cleanup without holding locks
             // Defense-in-depth: catch ObjectDisposedException in case an event handler was already
@@ -1971,9 +2183,7 @@ namespace Centrifugal.Centrifuge
 
             try
             {
-                _reconnectCts?.Cancel();
-                ClearRefreshTimer();
-                _transportWasOpen = false;
+                lock (_stateChangeLock) { ClearRefreshTimer(); }
 
                 // Clean up transport (ping timer, events, close, dispose)
                 await CleanupTransportAsync().ConfigureAwait(false);
@@ -1997,15 +2207,33 @@ namespace Centrifugal.Centrifuge
             }
         }
 
-        private void SetState(CentrifugeClientState newState)
+        private CentrifugeClientState SetState(CentrifugeClientState newState)
         {
             var oldState = _state;
             _state = newState;
+            if (oldState != newState) _epoch++;
+            return oldState;
+        }
 
-            if (oldState != newState)
+        internal async Task HandleNoPingAsync()
+        {
+            CentrifugeClientState prevState;
+            lock (_stateChangeLock)
             {
-                StateChanged?.Invoke(this, new CentrifugeStateEventArgs(oldState, newState));
+                if (_state != CentrifugeClientState.Connected) return;
+                _reconnectCts?.Cancel();
+                prevState = SetState(CentrifugeClientState.Connecting);
             }
+
+            foreach (var sub in _subscriptions.Values)
+                sub.MoveToSubscribing(CentrifugeSubscribingCodes.TransportClosed, "transport closed");
+
+            if (prevState != CentrifugeClientState.Connecting)
+                StateChanged?.Invoke(this, new CentrifugeStateEventArgs(prevState, CentrifugeClientState.Connecting));
+            Connecting?.Invoke(this, new CentrifugeConnectingEventArgs(CentrifugeConnectingCodes.NoPing, "no ping"));
+
+            await CleanupTransportAsync().ConfigureAwait(false);
+            await ScheduleReconnectAsync().ConfigureAwait(false);
         }
 
         private void StartPingTimer(uint pingInterval)
@@ -2015,74 +2243,77 @@ namespace Centrifugal.Centrifuge
             var interval = (int)(pingInterval * 1000) + (int)_options.MaxServerPingDelay.TotalMilliseconds;
             _pingTimer = new Timer(_ =>
             {
-                _ = StartConnectingAsync(CentrifugeConnectingCodes.NoPing, "no ping");
+                _ = HandleNoPingAsync();
             }, null, interval, System.Threading.Timeout.Infinite);
         }
 
         private void ResetPingTimer()
         {
-            if (_pingTimer == null || _serverPingInterval == 0 || _state != CentrifugeClientState.Connected)
+            Timer? timer;
+            uint pingInterval;
+            lock (_stateChangeLock)
             {
-                return;
+                if (_pingTimer == null || _serverPingInterval == 0 || _state != CentrifugeClientState.Connected)
+                    return;
+                timer = _pingTimer;
+                pingInterval = _serverPingInterval;
             }
-
-            var interval = (int)(_serverPingInterval * 1000) + (int)_options.MaxServerPingDelay.TotalMilliseconds;
-            _pingTimer.Change(interval, System.Threading.Timeout.Infinite);
+            var interval = (int)(pingInterval * 1000) + (int)_options.MaxServerPingDelay.TotalMilliseconds;
+            try { timer.Change(interval, System.Threading.Timeout.Infinite); }
+            catch (ObjectDisposedException) { }
         }
 
         private void HandleServerPing()
         {
-            if (_sendPong)
+            bool sendPong;
+            ITransport? transport;
+            string? session, node;
+            lock (_stateChangeLock)
             {
-                // Send empty command as pong
-                var cmd = new Command
-                {
-                    // No Id, no payload - just empty command
-                };
+                sendPong = _sendPong;
+                transport = _transport;
+                session = _session;
+                node = _node;
+            }
 
-                try
-                {
-                    if (_transport != null)
-                    {
-                        if (_transport.UsesEmulation)
-                        {
-                            // For emulation transports (non-connect commands), use SendEmulationAsync with session and node
-                            // The command must be varint-delimited
-                            using var ms = new MemoryStream();
-                            VarintCodec.WriteDelimitedMessage(ms, cmd.ToByteArray());
-                            var delimitedCommand = ms.ToArray();
+            if (!sendPong || transport == null) return;
 
-                            var emulationEndpoint = GetEmulationEndpoint();
-                            // Fire-and-forget: this runs on the receive thread; observe the
-                            // task so a faulted send doesn't surface as an unobserved exception.
-                            _ = _transport.SendEmulationAsync(delimitedCommand, _session, _node, emulationEndpoint, CancellationToken.None).ContinueWith(
-                                t => { _ = t.Exception; },
-                                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
-                        }
-                        else
-                        {
-                            // For WebSocket, wrap with varint delimiter.
-                            // Fire-and-forget: this runs on the receive thread; blocking on
-                            // SendAsync here would stall message processing.
-                            using var ms = new MemoryStream();
-                            VarintCodec.WriteDelimitedMessage(ms, cmd.ToByteArray());
-                            var pongBytes = ms.ToArray();
-                            _ = _transport.SendAsync(pongBytes).ContinueWith(
-                                t => { _ = t.Exception; },
-                                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
-                        }
-                    }
-                }
-                catch
+            var cmd = new Command { };
+
+            try
+            {
+                if (transport.UsesEmulation)
                 {
-                    // Ignore errors sending pong
+                    using var ms = new MemoryStream();
+                    VarintCodec.WriteDelimitedMessage(ms, cmd.ToByteArray());
+                    var delimitedCommand = ms.ToArray();
+                    var emulationEndpoint = GetEmulationEndpoint();
+                    _ = transport.SendEmulationAsync(delimitedCommand, session, node, emulationEndpoint, CancellationToken.None).ContinueWith(
+                        t => { _ = t.Exception; },
+                        TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
                 }
+                else
+                {
+                    using var ms = new MemoryStream();
+                    VarintCodec.WriteDelimitedMessage(ms, cmd.ToByteArray());
+                    var pongBytes = ms.ToArray();
+                    _ = transport.SendAsync(pongBytes).ContinueWith(
+                        t => { _ = t.Exception; },
+                        TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
+                }
+            }
+            catch
+            {
+                // Ignore errors sending pong
             }
         }
 
         private void ScheduleConnectionRefresh(uint ttl)
         {
             _refreshTimer?.Dispose();
+            _refreshTimer = null;
+            // ttl=0 means "no expiry given" — skip scheduling rather than busy-loop.
+            if (ttl == 0) return;
             var delay = Utilities.TtlToMilliseconds(ttl);
             _refreshTimer = new Timer(_ => _ = RefreshConnectionTokenAsync(), null, delay, System.Threading.Timeout.Infinite);
         }
@@ -2093,11 +2324,13 @@ namespace Centrifugal.Centrifuge
             _refreshTimer = null;
         }
 
-        private async Task RefreshConnectionTokenAsync()
+        internal async Task RefreshConnectionTokenAsync()
         {
-            if (_state != CentrifugeClientState.Connected || _options.GetToken == null)
+            int epochSnapshot;
+            lock (_stateChangeLock)
             {
-                return;
+                if (_state != CentrifugeClientState.Connected || _options.GetToken == null) return;
+                epochSnapshot = _epoch;
             }
 
             try
@@ -2105,12 +2338,15 @@ namespace Centrifugal.Centrifuge
                 var token = await _options.GetToken().ConfigureAwait(false);
                 if (string.IsNullOrEmpty(token))
                 {
-                    await SetDisconnectedAsync(CentrifugeDisconnectedCodes.Unauthorized, "unauthorized", false).ConfigureAwait(false);
+                    await SetDisconnectedAsync(CentrifugeDisconnectedCodes.Unauthorized, "unauthorized").ConfigureAwait(false);
                     return;
                 }
 
                 lock (_stateChangeLock)
                 {
+                    // Discard the token if the connection left/re-entered Connected during the await —
+                    // the token belongs to a prior session.
+                    if (_state != CentrifugeClientState.Connected || _epoch != epochSnapshot) return;
                     _options.Token = token;
                 }
 
@@ -2140,68 +2376,57 @@ namespace Centrifugal.Centrifuge
             }
             catch (CentrifugeUnauthorizedException)
             {
-                await SetDisconnectedAsync(CentrifugeDisconnectedCodes.Unauthorized, "unauthorized", false).ConfigureAwait(false);
+                await SetDisconnectedAsync(CentrifugeDisconnectedCodes.Unauthorized, "unauthorized").ConfigureAwait(false);
             }
             catch (Exception ex)
             {
                 OnError("refreshToken", ex);
-                // Schedule retry
-                var delay = Utilities.CalculateBackoff(_refreshAttempts, _options.MinReconnectDelay, _options.MaxReconnectDelay);
-                _refreshAttempts++;
-                _refreshTimer?.Dispose();
-                _refreshTimer = new Timer(_ => _ = RefreshConnectionTokenAsync(), null, delay, System.Threading.Timeout.Infinite);
+                lock (_stateChangeLock)
+                {
+                    if (_state != CentrifugeClientState.Connected) return;
+                    var delay = Utilities.CalculateBackoff(_refreshAttempts, _options.MinReconnectDelay, _options.MaxReconnectDelay);
+                    _refreshAttempts++;
+                    ClearRefreshTimer();
+                    _refreshTimer = new Timer(_ => _ = RefreshConnectionTokenAsync(), null, delay, System.Threading.Timeout.Infinite);
+                }
             }
         }
 
         private void HandleRefreshReply(RefreshResult result)
         {
-            if (_state != CentrifugeClientState.Connected)
+            lock (_stateChangeLock)
             {
-                return;
-            }
-
-            ClearRefreshTimer();
-            _refreshAttempts = 0;
-            _clientId = result.Client;
-
-            // Schedule next refresh if token expires
-            if (result.Expires)
-            {
-                ScheduleConnectionRefresh(result.Ttl);
+                if (_state != CentrifugeClientState.Connected) return;
+                ClearRefreshTimer();
+                _refreshAttempts = 0;
+                _clientId = result.Client;
+                if (result.Expires)
+                {
+                    ScheduleConnectionRefresh(result.Ttl);
+                }
             }
         }
 
         private void HandleRefreshError(CentrifugeException error)
         {
-            // If error is temporary, retry with backoff
             if (error.Code < 100 || error.Temporary)
             {
                 OnError("refreshToken", error);
-                var delay = Utilities.CalculateBackoff(_refreshAttempts, _options.MinReconnectDelay, _options.MaxReconnectDelay);
-                _refreshAttempts++;
-                _refreshTimer?.Dispose();
-                _refreshTimer = new Timer(_ => _ = RefreshConnectionTokenAsync(), null, delay, System.Threading.Timeout.Infinite);
+                lock (_stateChangeLock)
+                {
+                    if (_state != CentrifugeClientState.Connected) return;
+                    var delay = Utilities.CalculateBackoff(_refreshAttempts, _options.MinReconnectDelay, _options.MaxReconnectDelay);
+                    _refreshAttempts++;
+                    ClearRefreshTimer();
+                    _refreshTimer = new Timer(_ => _ = RefreshConnectionTokenAsync(), null, delay, System.Threading.Timeout.Infinite);
+                }
             }
             else
             {
-                // Permanent error - disconnect
-                _ = SetDisconnectedAsync((int)error.Code, error.Message, false);
+                _ = SetDisconnectedAsync((int)error.Code, error.Message);
             }
         }
 
-        private void ClearInflightRequests()
-        {
-            // Cancel all pending requests with connection closed error
-            foreach (var kvp in _pendingCalls)
-            {
-                kvp.Value.TrySetException(new CentrifugeException(
-                    CentrifugeErrorCodes.ConnectionClosed,
-                    "connection closed",
-                    false
-                ));
-            }
-            _pendingCalls.Clear();
-        }
 
         private void ProcessServerSubscriptions(Google.Protobuf.Collections.MapField<string, SubscribeResult> subs)
         {
@@ -2219,20 +2444,23 @@ namespace Centrifugal.Centrifuge
                 var sub = kvp.Value;
                 subsToKeep.Add(channel);
 
-                bool wasRecovering = _serverSubscriptions.ContainsKey(channel);
+                bool wasRecovering;
+                lock (_stateChangeLock)
+                {
+                    wasRecovering = _serverSubscriptions.ContainsKey(channel);
+                    _serverSubscriptions[channel] = new ServerSubscription
+                    {
+                        Offset = sub.Offset,
+                        Epoch = sub.Epoch,
+                        Recoverable = sub.Recoverable
+                    };
+                }
 
                 // Fire ServerSubscribing event for new subscriptions
                 if (!wasRecovering)
                 {
                     ServerSubscribing?.Invoke(this, new CentrifugeServerSubscribingEventArgs(channel));
                 }
-
-                _serverSubscriptions[channel] = new ServerSubscription
-                {
-                    Offset = sub.Offset,
-                    Epoch = sub.Epoch,
-                    Recoverable = sub.Recoverable
-                };
 
                 CentrifugeStreamPosition? streamPosition = null;
                 if (sub.Positioned)
@@ -2260,7 +2488,19 @@ namespace Centrifugal.Centrifuge
 
                         if (sub.Positioned && pub.Offset > 0)
                         {
-                            _serverSubscriptions[channel].Offset = pub.Offset;
+                            lock (_stateChangeLock)
+                            {
+                                if (_serverSubscriptions.TryGetValue(channel, out var existing) &&
+                                    pub.Offset > existing.Offset)
+                                {
+                                    _serverSubscriptions[channel] = new ServerSubscription
+                                    {
+                                        Offset = pub.Offset,
+                                        Epoch = existing.Epoch,
+                                        Recoverable = existing.Recoverable
+                                    };
+                                }
+                            }
                         }
                     }
                 }
@@ -2285,14 +2525,17 @@ namespace Centrifugal.Centrifuge
 
         private void HandleServerSubscribe(string channel, Subscribe sub)
         {
-            bool wasRecovering = _serverSubscriptions.ContainsKey(channel);
-
-            _serverSubscriptions[channel] = new ServerSubscription
+            bool wasRecovering;
+            lock (_stateChangeLock)
             {
-                Offset = sub.Offset,
-                Epoch = sub.Epoch,
-                Recoverable = sub.Recoverable
-            };
+                wasRecovering = _serverSubscriptions.ContainsKey(channel);
+                _serverSubscriptions[channel] = new ServerSubscription
+                {
+                    Offset = sub.Offset,
+                    Epoch = sub.Epoch,
+                    Recoverable = sub.Recoverable
+                };
+            }
 
             CentrifugeStreamPosition? streamPosition = null;
             if (sub.Positioned)
@@ -2333,11 +2576,15 @@ namespace Centrifugal.Centrifuge
                     _ = clientSub.ResubscribeAsync();
                 }
             }
-            else if (_serverSubscriptions.ContainsKey(channel))
+            else
             {
-                // Server-side subscription
-                _serverSubscriptions.TryRemove(channel, out _);
-                ServerUnsubscribed?.Invoke(this, new CentrifugeServerUnsubscribedEventArgs(channel));
+                bool removed;
+                lock (_stateChangeLock)
+                {
+                    removed = _serverSubscriptions.TryRemove(channel, out _);
+                }
+                if (removed)
+                    ServerUnsubscribed?.Invoke(this, new CentrifugeServerUnsubscribedEventArgs(channel));
             }
         }
 
@@ -2348,7 +2595,14 @@ namespace Centrifugal.Centrifuge
 
         internal uint NextCommandId()
         {
-            return (uint)Interlocked.Increment(ref _commandId);
+            // The protocol uses uint32 ids; id == 0 is reserved for push messages
+            // (no reply), so skip it on wrap-around to avoid colliding with pushes.
+            uint id;
+            do
+            {
+                id = (uint)Interlocked.Increment(ref _commandId);
+            } while (id == 0);
+            return id;
         }
 
         private int NextPromiseId()
@@ -2415,17 +2669,19 @@ namespace Centrifugal.Centrifuge
         /// </summary>
         public async ValueTask DisposeAsync()
         {
-            if (_disposed) return;
-            _disposed = true;
+            if (System.Threading.Interlocked.CompareExchange(ref _disposed, 1, 0) != 0) return;
 
             try
             {
-                await SetDisconnectedAsync(CentrifugeDisconnectedCodes.DisconnectCalled, "disconnect called", false).ConfigureAwait(false);
+                await SetDisconnectedAsync(CentrifugeDisconnectedCodes.DisconnectCalled, "disconnect called").ConfigureAwait(false);
             }
             catch
             {
                 // Suppress exceptions during disposal - we're shutting down anyway
             }
+
+            foreach (var sub in _subscriptions.Values) sub.Dispose();
+            _subscriptions.Clear();
 
             _stateLock?.Dispose();
             _reconnectCts?.Dispose();
@@ -2440,12 +2696,11 @@ namespace Centrifugal.Centrifuge
         /// </summary>
         public void Dispose()
         {
-            if (_disposed) return;
-            _disposed = true;
+            if (System.Threading.Interlocked.CompareExchange(ref _disposed, 1, 0) != 0) return;
 
             try
             {
-                SetDisconnectedAsync(CentrifugeDisconnectedCodes.DisconnectCalled, "disconnect called", false)
+                SetDisconnectedAsync(CentrifugeDisconnectedCodes.DisconnectCalled, "disconnect called")
                     .ConfigureAwait(false)
                     .GetAwaiter()
                     .GetResult();
@@ -2454,6 +2709,9 @@ namespace Centrifugal.Centrifuge
             {
                 // Suppress exceptions during disposal - we're shutting down anyway
             }
+
+            foreach (var sub in _subscriptions.Values) sub.Dispose();
+            _subscriptions.Clear();
 
             _stateLock?.Dispose();
             _reconnectCts?.Dispose();

--- a/src/Centrifugal.Centrifuge/Subscription.cs
+++ b/src/Centrifugal.Centrifuge/Subscription.cs
@@ -11,15 +11,16 @@ namespace Centrifugal.Centrifuge
     /// <summary>
     /// Represents a subscription to a channel.
     /// </summary>
-    public class CentrifugeSubscription
+    public class CentrifugeSubscription : IDisposable
     {
         private readonly CentrifugeClient _client;
         private readonly CentrifugeSubscriptionOptions _options;
         private readonly SemaphoreSlim _stateLock = new SemaphoreSlim(1, 1);
         private readonly object _stateChangeLock = new object();
+        private readonly object _deltaLock = new object();
         private readonly ConcurrentDictionary<int, TaskCompletionSource<bool>> _readyPromises = new();
 
-        private CentrifugeSubscriptionState _state = CentrifugeSubscriptionState.Unsubscribed;
+        private volatile CentrifugeSubscriptionState _state = CentrifugeSubscriptionState.Unsubscribed;
         private int _resubscribeAttempts;
         private CancellationTokenSource? _resubscribeCts;
         private CentrifugeStreamPosition? _streamPosition;
@@ -30,6 +31,8 @@ namespace Centrifugal.Centrifuge
         private bool _refreshRequired;
         private int _promiseId;
         private bool _inflight;
+        private int _disposed;
+        private int _epoch;
 
         /// <summary>
         /// Gets the channel name.
@@ -100,18 +103,22 @@ namespace Centrifugal.Centrifuge
         /// </summary>
         public void Subscribe()
         {
-            if (_state == CentrifugeSubscriptionState.Subscribed)
+            ThrowIfDisposed();
+            lock (_stateChangeLock)
             {
-                return;
+                if (_state == CentrifugeSubscriptionState.Subscribed || _state == CentrifugeSubscriptionState.Subscribing)
+                {
+                    return;
+                }
+                _resubscribeAttempts = 0;
             }
-
-            if (_state == CentrifugeSubscriptionState.Subscribing)
-            {
-                return;
-            }
-
-            _resubscribeAttempts = 0;
             StartSubscribing();
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (System.Threading.Interlocked.CompareExchange(ref _disposed, 0, 0) != 0)
+                throw new ObjectDisposedException(nameof(CentrifugeSubscription));
         }
 
         /// <summary>
@@ -425,20 +432,7 @@ namespace Centrifugal.Centrifuge
 
         internal async Task ResubscribeAsync()
         {
-            await _stateLock.WaitAsync().ConfigureAwait(false);
-            try
-            {
-                if (_state == CentrifugeSubscriptionState.Unsubscribed)
-                {
-                    return;
-                }
-
-                await StartSubscribingAsync(CentrifugeSubscribingCodes.TransportClosed, "transport closed").ConfigureAwait(false);
-            }
-            finally
-            {
-                _stateLock.Release();
-            }
+            await StartSubscribingAsync(CentrifugeSubscribingCodes.TransportClosed, "transport closed").ConfigureAwait(false);
         }
 
         /// <summary>
@@ -446,31 +440,42 @@ namespace Centrifugal.Centrifuge
         /// </summary>
         internal void MoveToSubscribing(int code, string reason)
         {
+            CentrifugeSubscriptionState prevState;
             lock (_stateChangeLock)
             {
-                if (_state != CentrifugeSubscriptionState.Subscribed)
+                if (_state == CentrifugeSubscriptionState.Unsubscribed) return;
+
+                if (_state == CentrifugeSubscriptionState.Subscribing)
                 {
+                    _resubscribeCts?.Cancel();
                     return;
                 }
 
-                SetState(CentrifugeSubscriptionState.Subscribing);
-                Subscribing?.Invoke(this, new CentrifugeSubscribingEventArgs(code, reason));
+                prevState = SetState(CentrifugeSubscriptionState.Subscribing);
+                _resubscribeCts?.Cancel();
             }
+            if (prevState != CentrifugeSubscriptionState.Subscribing)
+                StateChanged?.Invoke(this, new CentrifugeSubscriptionStateEventArgs(prevState, CentrifugeSubscriptionState.Subscribing));
+            Subscribing?.Invoke(this, new CentrifugeSubscribingEventArgs(code, reason));
         }
 
         private void StartSubscribing()
         {
-            SetState(CentrifugeSubscriptionState.Subscribing);
+            CentrifugeSubscriptionState prevState;
+            lock (_stateChangeLock)
+            {
+                if (_state != CentrifugeSubscriptionState.Unsubscribed)
+                {
+                    return;
+                }
+                prevState = SetState(CentrifugeSubscriptionState.Subscribing);
+            }
+            if (prevState != CentrifugeSubscriptionState.Subscribing)
+                StateChanged?.Invoke(this, new CentrifugeSubscriptionStateEventArgs(prevState, CentrifugeSubscriptionState.Subscribing));
             Subscribing?.Invoke(this, new CentrifugeSubscribingEventArgs(CentrifugeSubscribingCodes.SubscribeCalled, "subscribe called"));
 
-            // If not connected, the subscription will be sent when connection is established
-            if (_client.State != CentrifugeClientState.Connected)
-            {
-                return;
-            }
-
-            // If connected, schedule subscribe command to be sent in a batch
-            // This allows multiple subscribe calls to be automatically batched together
+            // Schedule subscribe batch; SendSubscribeIfNeededAsync does the authoritative
+            // locked state check, so no bare _client.State read needed here.
             _client.ScheduleSubscribeBatch();
         }
 
@@ -494,131 +499,108 @@ namespace Centrifugal.Centrifuge
                 _inflight = true;
             }
 
-            // Check state again after releasing lock - it could have changed to Unsubscribed
-            // This prevents sending subscribe command if Unsubscribe() was called
-            if (_state != CentrifugeSubscriptionState.Subscribing)
-            {
-                lock (_stateChangeLock)
-                {
-                    _inflight = false;
-                }
-                return;
-            }
-
+            bool inflightClearedEarly = false;
             try
             {
                 await SendSubscribeCommandAsync().ConfigureAwait(false);
             }
             catch (CentrifugeTimeoutException)
             {
-                // Subscribe timeout should trigger client reconnect, just like in centrifuge-js
+                lock (_stateChangeLock) { _inflight = false; }
+                inflightClearedEarly = true;
                 OnError("subscribe", new CentrifugeException(CentrifugeErrorCodes.Timeout, "subscribe timeout", true));
-                // Trigger client disconnect with reconnect
                 await _client.HandleSubscribeTimeoutAsync().ConfigureAwait(false);
             }
             catch (CentrifugeUnauthorizedException)
             {
+                lock (_stateChangeLock) { _inflight = false; }
+                inflightClearedEarly = true;
                 await SetUnsubscribedAsync(CentrifugeUnsubscribedCodes.Unauthorized, "unauthorized").ConfigureAwait(false);
             }
             catch (CentrifugeException ex)
             {
                 OnError("subscribe", ex);
-                // Temporary errors or token expired (109) - schedule resubscribe
-                // Permanent errors - unsubscribe (matching centrifuge-js behavior)
                 if (ex.Code < 100 || ex.Code == 109 || ex.Temporary)
                 {
-                    if (ex.Code == 109)
+                    lock (_stateChangeLock)
                     {
-                        _refreshRequired = true;
+                        if (ex.Code == 109) _refreshRequired = true;
+                        // Release _inflight BEFORE ScheduleResubscribeAsync so the retry's
+                        // inner SendSubscribeIfNeededAsync can re-acquire it. The finally block
+                        // must NOT clear it again — that would corrupt a concurrent caller that
+                        // acquired _inflight between here and the finally.
+                        _inflight = false;
                     }
+                    inflightClearedEarly = true;
                     await ScheduleResubscribeAsync().ConfigureAwait(false);
+                    return;
                 }
                 else
                 {
+                    // Permanent error — release _inflight BEFORE SetUnsubscribedAsync so a
+                    // user handler that calls Subscribe() in response to the Unsubscribed
+                    // event isn't blocked by our still-held inflight flag.
+                    lock (_stateChangeLock) { _inflight = false; }
+                    inflightClearedEarly = true;
                     await SetUnsubscribedAsync(ex.Code, ex.Message).ConfigureAwait(false);
                 }
             }
             catch (Exception ex)
             {
                 OnError("subscribe", ex);
+                lock (_stateChangeLock) { _inflight = false; }
+                inflightClearedEarly = true;
                 await ScheduleResubscribeAsync().ConfigureAwait(false);
+                return;
             }
             finally
             {
-                lock (_stateChangeLock)
+                if (!inflightClearedEarly)
                 {
-                    _inflight = false;
+                    lock (_stateChangeLock) { _inflight = false; }
                 }
             }
         }
 
         private async Task StartSubscribingAsync(int code, string reason)
         {
-            SetState(CentrifugeSubscriptionState.Subscribing);
+            // State check and transition must be atomic with _stateChangeLock so a concurrent
+            // SetUnsubscribedAsync (user's Unsubscribe()) can't be overwritten by this method.
+            CentrifugeSubscriptionState prevState;
+            lock (_stateChangeLock)
+            {
+                if (_state == CentrifugeSubscriptionState.Unsubscribed) return;
+                prevState = SetState(CentrifugeSubscriptionState.Subscribing);
+            }
+
+            if (prevState != CentrifugeSubscriptionState.Subscribing)
+                StateChanged?.Invoke(this, new CentrifugeSubscriptionStateEventArgs(prevState, CentrifugeSubscriptionState.Subscribing));
             Subscribing?.Invoke(this, new CentrifugeSubscribingEventArgs(code, reason));
 
-            if (_client.State != CentrifugeClientState.Connected)
-            {
-                // Wait for client to connect
-                return;
-            }
-
-            try
-            {
-                await SendSubscribeCommandAsync().ConfigureAwait(false);
-            }
-            catch (CentrifugeTimeoutException)
-            {
-                // Subscribe timeout should trigger client reconnect, just like in centrifuge-js
-                OnError("subscribe", new CentrifugeException(CentrifugeErrorCodes.Timeout, "subscribe timeout", true));
-                // Trigger client disconnect with reconnect
-                await _client.HandleSubscribeTimeoutAsync().ConfigureAwait(false);
-            }
-            catch (CentrifugeUnauthorizedException)
-            {
-                await SetUnsubscribedAsync(CentrifugeUnsubscribedCodes.Unauthorized, "unauthorized").ConfigureAwait(false);
-            }
-            catch (CentrifugeException ex)
-            {
-                OnError("subscribe", ex);
-                // Temporary errors or token expired (109) - schedule resubscribe
-                // Permanent errors - unsubscribe (matching centrifuge-js behavior)
-                if (ex.Code < 100 || ex.Code == 109 || ex.Temporary)
-                {
-                    if (ex.Code == 109)
-                    {
-                        _refreshRequired = true;
-                    }
-                    await ScheduleResubscribeAsync().ConfigureAwait(false);
-                }
-                else
-                {
-                    await SetUnsubscribedAsync(ex.Code, ex.Message).ConfigureAwait(false);
-                }
-            }
-            catch (Exception ex)
-            {
-                OnError("subscribe", ex);
-                await ScheduleResubscribeAsync().ConfigureAwait(false);
-            }
+            // SendSubscribeIfNeededAsync does the authoritative locked state check internally;
+            // no bare _client.State read needed here.
+            await SendSubscribeIfNeededAsync().ConfigureAwait(false);
         }
 
         private async Task SendSubscribeCommandAsync()
         {
             string? token;
+            bool needsRefresh;
             lock (_stateChangeLock)
             {
                 token = _options.Token;
+                needsRefresh = _refreshRequired;
             }
 
             // If refresh is required or token is empty, try to get a new token
-            if ((string.IsNullOrEmpty(token) || _refreshRequired) && _options.GetToken != null)
+            if ((string.IsNullOrEmpty(token) || needsRefresh) && _options.GetToken != null)
             {
                 try
                 {
                     token = await _options.GetToken(Channel).ConfigureAwait(false);
                     lock (_stateChangeLock)
                     {
+                        if (_state != CentrifugeSubscriptionState.Subscribing) return;
                         _options.Token = token;
                     }
                 }
@@ -646,11 +628,13 @@ namespace Centrifugal.Centrifuge
                 JoinLeave = _options.JoinLeave
             };
 
-            if (_streamPosition != null)
+            CentrifugeStreamPosition? streamPos;
+            lock (_stateChangeLock) { streamPos = _streamPosition; }
+            if (streamPos != null)
             {
                 request.Recover = true;
-                request.Epoch = _streamPosition.Value.Epoch;
-                request.Offset = _streamPosition.Value.Offset;
+                request.Epoch = streamPos.Value.Epoch;
+                request.Offset = streamPos.Value.Offset;
             }
 
             if (!data.IsEmpty)
@@ -681,7 +665,7 @@ namespace Centrifugal.Centrifuge
                 // Error code 109 means token expired - mark for refresh on next subscribe
                 if (reply.Error.Code == 109)
                 {
-                    _refreshRequired = true;
+                    lock (_stateChangeLock) { _refreshRequired = true; }
                 }
 
                 throw new CentrifugeException(
@@ -696,14 +680,21 @@ namespace Centrifugal.Centrifuge
 
         private void HandleSubscribeReply(SubscribeResult result)
         {
-            bool wasRecovering = _streamPosition != null;
+            // Reply arrived after Dispose() — drop it to avoid creating a Timer/CTS that
+            // never gets cleaned up.
+            if (System.Threading.Interlocked.CompareExchange(ref _disposed, 0, 0) != 0) return;
+
             bool recovered = result.Recovered;
 
             // Hold _stateChangeLock across the unsubscribed-check, the state transition
             // and ResolvePromises so a ReadyAsync caller can't observe Subscribing,
             // miss our resolve, and then register a tcs that nobody will complete.
+            bool wasRecovering;
+            CentrifugeStreamPosition? streamPositionSnapshot;
+            CentrifugeSubscriptionState prevState;
             lock (_stateChangeLock)
             {
+                wasRecovering = _streamPosition != null;
                 if (_state == CentrifugeSubscriptionState.Unsubscribed)
                 {
                     // Subscription was unsubscribed during subscribe, ignore the reply
@@ -715,14 +706,15 @@ namespace Centrifugal.Centrifuge
                     _streamPosition = new CentrifugeStreamPosition(result.Offset, result.Epoch);
                 }
 
-                // Check if delta compression was negotiated with server
-                if (result.Delta)
+                // Re-negotiate delta state for this subscribe session. The previous session's
+                // _prevValue MUST be cleared: the server starts a fresh delta chain on every
+                // subscribe reply (its first publication is a full snapshot), so applying a
+                // delta against the prior session's bytes would corrupt the payload.
+                // Take _deltaLock so concurrent ApplyDeltaIfNeeded callers see the new
+                // value through the same lock that guards the delta state.
+                lock (_deltaLock)
                 {
-                    _deltaNegotiated = true;
-                }
-                else
-                {
-                    _deltaNegotiated = false;
+                    _deltaNegotiated = result.Delta;
                     _prevValue = null;
                 }
 
@@ -737,32 +729,51 @@ namespace Centrifugal.Centrifuge
                     ScheduleTokenRefresh(result.Ttl);
                 }
 
-                SetState(CentrifugeSubscriptionState.Subscribed);
+                prevState = SetState(CentrifugeSubscriptionState.Subscribed);
+                _resubscribeAttempts = 0;
+
+                // Capture stream position under lock so the Subscribed event sees a consistent snapshot.
+                streamPositionSnapshot = _streamPosition;
 
                 // Resolve ready promises
                 ResolvePromises();
             }
+
+            if (prevState != CentrifugeSubscriptionState.Subscribed)
+                StateChanged?.Invoke(this, new CentrifugeSubscriptionStateEventArgs(prevState, CentrifugeSubscriptionState.Subscribed));
 
             Subscribed?.Invoke(this, new CentrifugeSubscribedEventArgs(
                 wasRecovering,
                 recovered,
                 result.Recoverable,
                 result.Positioned,
-                _streamPosition,
+                streamPositionSnapshot,
                 result.Data.ToByteArray()
             ));
 
-            _resubscribeAttempts = 0;
-
-            // Dispatch recovered publications
+            // Dispatch recovered publications.
+            // Isolate handler exceptions: a single throwing Publication handler must not
+            // abort the recovery loop (would drop remaining publications and skip the
+            // _streamPosition advance, mis-sequencing future live publications).
             foreach (var pub in result.Publications)
             {
                 var pubArgs = ApplyDeltaIfNeeded(pub);
-                Publication?.Invoke(this, pubArgs);
+                try
+                {
+                    Publication?.Invoke(this, pubArgs);
+                }
+                catch (Exception ex)
+                {
+                    OnError("publication", ex);
+                }
 
                 if (result.Positioned && pub.Offset > 0)
                 {
-                    _streamPosition = new CentrifugeStreamPosition(pub.Offset, result.Epoch);
+                    lock (_stateChangeLock)
+                    {
+                        if (_streamPosition == null || pub.Offset > _streamPosition.Value.Offset)
+                            _streamPosition = new CentrifugeStreamPosition(pub.Offset, result.Epoch);
+                    }
                 }
             }
         }
@@ -772,9 +783,13 @@ namespace Centrifugal.Centrifuge
             var pubArgs = ApplyDeltaIfNeeded(pub);
             Publication?.Invoke(this, pubArgs);
 
-            if (pub.Offset > 0 && _streamPosition != null)
+            if (pub.Offset > 0)
             {
-                _streamPosition = new CentrifugeStreamPosition(pub.Offset, _streamPosition.Value.Epoch);
+                lock (_stateChangeLock)
+                {
+                    if (_streamPosition != null && pub.Offset > _streamPosition.Value.Offset)
+                        _streamPosition = new CentrifugeStreamPosition(pub.Offset, _streamPosition.Value.Epoch);
+                }
             }
         }
 
@@ -782,15 +797,22 @@ namespace Centrifugal.Centrifuge
         {
             var data = pub.Data.ToByteArray();
 
-            // Apply delta decompression if negotiated with server
-            if (!string.IsNullOrEmpty(_options.Delta) && _deltaNegotiated)
+            // Hold _deltaLock (not _stateChangeLock) across the full read-apply-write sequence so concurrent callers
+            // (HandleSubscribeReply recovery loop + HandlePublication live stream) can't
+            // both read the same _prevValue and then corrupt the delta chain with two
+            // independent writes. A dedicated lock keeps O(payload-size) Fossil decode
+            // off the hot state-change path.
+            if (!string.IsNullOrEmpty(_options.Delta))
             {
-                if (_prevValue != null && data.Length > 0)
+                lock (_deltaLock)
                 {
-                    // Apply fossil delta to get the actual publication data
-                    data = Fossil.ApplyDelta(_prevValue, data);
+                    if (_deltaNegotiated)
+                    {
+                        if (_prevValue != null && data.Length > 0)
+                            data = Fossil.ApplyDelta(_prevValue, data);
+                        _prevValue = data;
+                    }
                 }
-                _prevValue = data;
             }
 
             return CentrifugeClient.CreatePublicationArgs(Channel, pub, data);
@@ -826,36 +848,49 @@ namespace Centrifugal.Centrifuge
 
         private async Task ScheduleResubscribeAsync()
         {
-            if (_state != CentrifugeSubscriptionState.Subscribing)
+            CancellationToken delayToken;
+            int currentAttempts;
+            lock (_stateChangeLock)
             {
-                return;
+                if (_state != CentrifugeSubscriptionState.Subscribing) return;
+                // Don't recreate _resubscribeCts after Dispose has nulled it — that would leak the CTS.
+                if (System.Threading.Interlocked.CompareExchange(ref _disposed, 0, 0) != 0) return;
+
+                var oldCts = _resubscribeCts;
+                _resubscribeCts = new CancellationTokenSource();
+                oldCts?.Cancel();
+                oldCts?.Dispose();
+                delayToken = _resubscribeCts.Token;
+                currentAttempts = _resubscribeAttempts++;
             }
 
-            var oldResubscribeCts = _resubscribeCts;
-            _resubscribeCts = new CancellationTokenSource();
-            oldResubscribeCts?.Cancel();
-            oldResubscribeCts?.Dispose();
-
             int delay = Utilities.CalculateBackoff(
-                _resubscribeAttempts++,
+                currentAttempts,
                 _options.MinResubscribeDelay,
                 _options.MaxResubscribeDelay
             );
 
             try
             {
-                await Task.Delay(delay, _resubscribeCts.Token).ConfigureAwait(false);
-                await SendSubscribeCommandAsync().ConfigureAwait(false);
+                await Task.Delay(delay, delayToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
-                // Resubscribe was cancelled
+                return;
             }
+
+            lock (_stateChangeLock)
+            {
+                if (_state != CentrifugeSubscriptionState.Subscribing) return;
+            }
+
+            await SendSubscribeIfNeededAsync().ConfigureAwait(false);
         }
 
         internal async Task SetUnsubscribedAsync(int code, string reason)
         {
             // Change state synchronously first
+            CentrifugeSubscriptionState prevState;
             lock (_stateChangeLock)
             {
                 if (_state == CentrifugeSubscriptionState.Unsubscribed)
@@ -863,58 +898,74 @@ namespace Centrifugal.Centrifuge
                     return;
                 }
 
-                SetState(CentrifugeSubscriptionState.Unsubscribed);
+                prevState = SetState(CentrifugeSubscriptionState.Unsubscribed);
 
                 // Reject ready promises
                 RejectPromises(new CentrifugeException(CentrifugeErrorCodes.SubscriptionUnsubscribed, "subscription unsubscribed"));
-
-                Unsubscribed?.Invoke(this, new CentrifugeUnsubscribedEventArgs(code, reason));
             }
 
-            // Now do async cleanup without holding locks
-            await _stateLock.WaitAsync().ConfigureAwait(false);
+            // Fire events outside the lock so re-entrant SDK calls in handlers don't deadlock.
+            if (prevState != CentrifugeSubscriptionState.Unsubscribed)
+                StateChanged?.Invoke(this, new CentrifugeSubscriptionStateEventArgs(prevState, CentrifugeSubscriptionState.Unsubscribed));
+            Unsubscribed?.Invoke(this, new CentrifugeUnsubscribedEventArgs(code, reason));
+
+            // Now do async cleanup without holding locks.
+            // Defense-in-depth: catch ObjectDisposedException because Dispose() may have
+            // disposed _stateLock between our state-change above and now.
             try
             {
-                _resubscribeCts?.Cancel();
-                ClearRefreshTimer();
-
-                if (_client.State == CentrifugeClientState.Connected)
+                await _stateLock.WaitAsync().ConfigureAwait(false);
+            }
+            catch (ObjectDisposedException)
+            {
+                return;
+            }
+            try
+            {
+                // Cancel/clear under _stateChangeLock — ScheduleResubscribeAsync and
+                // HandleRefreshError/etc. access these same fields under _stateChangeLock.
+                lock (_stateChangeLock)
                 {
-                    try
-                    {
-                        var cmd = new Command
-                        {
-                            Id = _client.NextCommandId(),
-                            Unsubscribe = new UnsubscribeRequest
-                            {
-                                Channel = Channel
-                            }
-                        };
+                    _resubscribeCts?.Cancel();
+                    ClearRefreshTimer();
+                }
 
-                        await _client.SendCommandAsync(cmd, CancellationToken.None).ConfigureAwait(false);
-                    }
-                    catch
+                try
+                {
+                    var cmd = new Command
                     {
-                        // Unsubscribe error triggers client disconnect with reconnect (matching centrifuge-js behavior)
-                        await _client.HandleUnsubscribeErrorAsync().ConfigureAwait(false);
-                    }
+                        Id = _client.NextCommandId(),
+                        Unsubscribe = new UnsubscribeRequest
+                        {
+                            Channel = Channel
+                        }
+                    };
+
+                    await _client.SendCommandAsync(cmd, CancellationToken.None).ConfigureAwait(false);
+                }
+                catch (CentrifugeException ex) when (
+                    ex.Code == CentrifugeErrorCodes.ClientDisconnected ||
+                    ex.Code == CentrifugeErrorCodes.ConnectionClosed)
+                {
+                    // Client was not connected — skip reconnect trigger
+                }
+                catch
+                {
+                    await _client.HandleUnsubscribeErrorAsync().ConfigureAwait(false);
                 }
             }
             finally
             {
-                _stateLock.Release();
+                try { _stateLock.Release(); } catch (ObjectDisposedException) { }
             }
         }
 
-        private void SetState(CentrifugeSubscriptionState newState)
+        private CentrifugeSubscriptionState SetState(CentrifugeSubscriptionState newState)
         {
             var oldState = _state;
             _state = newState;
-
-            if (oldState != newState)
-            {
-                StateChanged?.Invoke(this, new CentrifugeSubscriptionStateEventArgs(oldState, newState));
-            }
+            if (oldState != newState) _epoch++;
+            return oldState;
         }
 
         private void OnError(string type, Exception exception)
@@ -925,6 +976,9 @@ namespace Centrifugal.Centrifuge
         private void ScheduleTokenRefresh(uint ttl)
         {
             _refreshTimer?.Dispose();
+            _refreshTimer = null;
+            // ttl=0 means "no expiry given" — skip scheduling rather than busy-loop.
+            if (ttl == 0) return;
             var delay = Utilities.TtlToMilliseconds(ttl);
             _refreshTimer = new Timer(_ => _ = RefreshTokenAsync(), null, delay, Timeout.Infinite);
         }
@@ -935,11 +989,13 @@ namespace Centrifugal.Centrifuge
             _refreshTimer = null;
         }
 
-        private async Task RefreshTokenAsync()
+        internal async Task RefreshTokenAsync()
         {
-            if (_state != CentrifugeSubscriptionState.Subscribed || _options.GetToken == null)
+            int epochSnapshot;
+            lock (_stateChangeLock)
             {
-                return;
+                if (_state != CentrifugeSubscriptionState.Subscribed || _options.GetToken == null) return;
+                epochSnapshot = _epoch;
             }
 
             try
@@ -947,6 +1003,9 @@ namespace Centrifugal.Centrifuge
                 var token = await _options.GetToken(Channel).ConfigureAwait(false);
                 lock (_stateChangeLock)
                 {
+                    // Discard the token if the subscription left/re-entered Subscribed during the await —
+                    // the token belongs to a prior session.
+                    if (_state != CentrifugeSubscriptionState.Subscribed || _epoch != epochSnapshot) return;
                     _options.Token = token;
                 }
 
@@ -982,27 +1041,25 @@ namespace Centrifugal.Centrifuge
             }
             catch (Exception ex)
             {
-                // Network or temporary error - retry with exponential backoff
                 OnError("refresh", ex);
-                var delay = Utilities.CalculateBackoff(
-                    _refreshAttempts,
-                    _options.MinResubscribeDelay,
-                    _options.MaxResubscribeDelay
-                );
-                _refreshAttempts++;
-                _refreshTimer?.Dispose();
-                _refreshTimer = new Timer(_ => _ = RefreshTokenAsync(), null, delay, Timeout.Infinite);
+                lock (_stateChangeLock)
+                {
+                    if (_state != CentrifugeSubscriptionState.Subscribed) return;
+                    var delay = Utilities.CalculateBackoff(_refreshAttempts, _options.MinResubscribeDelay, _options.MaxResubscribeDelay);
+                    _refreshAttempts++;
+                    ClearRefreshTimer();
+                    _refreshTimer = new Timer(_ => _ = RefreshTokenAsync(), null, delay, Timeout.Infinite);
+                }
             }
         }
 
         private void HandleRefreshReply(SubRefreshResult result)
         {
-            _refreshAttempts = 0;
-
-            // Schedule next refresh if token still expires
-            if (result.Expires)
+            lock (_stateChangeLock)
             {
-                ScheduleTokenRefresh(result.Ttl);
+                if (_state != CentrifugeSubscriptionState.Subscribed) return;
+                _refreshAttempts = 0;
+                if (result.Expires) ScheduleTokenRefresh(result.Ttl);
             }
         }
 
@@ -1010,21 +1067,19 @@ namespace Centrifugal.Centrifuge
         {
             OnError("refresh", error);
 
-            // For temporary errors, retry with exponential backoff
             if (error.Temporary)
             {
-                var delay = Utilities.CalculateBackoff(
-                    _refreshAttempts,
-                    _options.MinResubscribeDelay,
-                    _options.MaxResubscribeDelay
-                );
-                _refreshAttempts++;
-                _refreshTimer?.Dispose();
-                _refreshTimer = new Timer(_ => _ = RefreshTokenAsync(), null, delay, Timeout.Infinite);
+                lock (_stateChangeLock)
+                {
+                    if (_state != CentrifugeSubscriptionState.Subscribed) return;
+                    var delay = Utilities.CalculateBackoff(_refreshAttempts, _options.MinResubscribeDelay, _options.MaxResubscribeDelay);
+                    _refreshAttempts++;
+                    ClearRefreshTimer();
+                    _refreshTimer = new Timer(_ => _ = RefreshTokenAsync(), null, delay, Timeout.Infinite);
+                }
             }
             else
             {
-                // Permanent error - unsubscribe
                 _ = SetUnsubscribedAsync(error.Code, error.Message);
             }
         }
@@ -1054,6 +1109,27 @@ namespace Centrifugal.Centrifuge
                     promise.TrySetException(error);
                 }
             }
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            if (System.Threading.Interlocked.CompareExchange(ref _disposed, 1, 0) != 0) return;
+
+            CancellationTokenSource? cts;
+            Timer? timer;
+            lock (_stateChangeLock)
+            {
+                cts = _resubscribeCts;
+                _resubscribeCts = null;
+                timer = _refreshTimer;
+                _refreshTimer = null;
+            }
+
+            try { cts?.Cancel(); } catch (ObjectDisposedException) { }
+            cts?.Dispose();
+            timer?.Dispose();
+            _stateLock.Dispose();
         }
     }
 }

--- a/src/Centrifugal.Centrifuge/Transports/BrowserHttpStreamTransport.cs
+++ b/src/Centrifugal.Centrifuge/Transports/BrowserHttpStreamTransport.cs
@@ -22,8 +22,9 @@ namespace Centrifugal.Centrifuge.Transports
         private IJSObjectReference? _jsModule;
         private DotNetObjectReference<BrowserHttpStreamTransport>? _dotnetRef;
         private int _streamId;
-        private bool _disposed;
-        private bool _isOpen;
+        private int _disposed;
+        private int _cleanupStarted;
+        private volatile bool _isOpen;
         private TaskCompletionSource<bool>? _openTcs;
         private MemoryStream _chunkBuffer = new();
         private readonly object _bufferLock = new object();
@@ -222,6 +223,8 @@ namespace Centrifugal.Centrifuge.Transports
         public void OnOpen()
         {
             _logger?.LogDebug($"OnOpen called for stream {_streamId}");
+            // Discard stale callback if CleanupAsync already ran (e.g. OpenAsync timed out).
+            if (System.Threading.Interlocked.CompareExchange(ref _cleanupStarted, 0, 0) != 0) return;
             // Set _isOpen BEFORE firing events so handlers can use the transport immediately
             _isOpen = true;
             var result = _openTcs?.TrySetResult(true);
@@ -305,28 +308,15 @@ namespace Centrifugal.Centrifuge.Transports
         [JSInvokable]
         public void OnError(int statusCode, string message)
         {
+            if (System.Threading.Interlocked.CompareExchange(ref _cleanupStarted, 0, 0) != 0) return;
             var exception = new Exception(message ?? "HTTP stream error");
             Error?.Invoke(this, exception);
 
-            // If we haven't opened yet, fail the open operation
+            // If we haven't opened yet, fail the open operation via openedTcs only.
+            // The caller's catch handler already schedules reconnect; firing Closed here
+            // would trigger HandleTransportClosedAsync concurrently → double reconnect.
             if (_openTcs != null && !_openTcs.Task.IsCompleted)
             {
-                // Map HTTP status code to close code
-                int closeCode;
-                if (statusCode == 400 || statusCode == 401 || statusCode == 403 ||
-                    statusCode == 404 || statusCode == 405)
-                {
-                    closeCode = CentrifugeDisconnectedCodes.BadProtocol;
-                }
-                else if (statusCode > 0)
-                {
-                    closeCode = CentrifugeConnectingCodes.TransportClosed;
-                }
-                else
-                {
-                    closeCode = 0;
-                }
-
                 var transportException = new CentrifugeException(
                     CentrifugeErrorCodes.TransportClosed,
                     message ?? "HTTP stream error",
@@ -334,9 +324,6 @@ namespace Centrifugal.Centrifuge.Transports
                     exception
                 );
                 _openTcs.TrySetException(transportException);
-
-                // Also trigger close event
-                Closed?.Invoke(this, new TransportClosedEventArgs(closeCode, message ?? "HTTP stream error", exception));
             }
         }
 
@@ -348,6 +335,7 @@ namespace Centrifugal.Centrifuge.Transports
         [JSInvokable]
         public void OnClose(int code, string reason)
         {
+            if (System.Threading.Interlocked.CompareExchange(ref _cleanupStarted, 0, 0) != 0) return;
             _isOpen = false;
             Closed?.Invoke(this, new TransportClosedEventArgs(code, reason));
             _ = CleanupAsync();
@@ -355,6 +343,7 @@ namespace Centrifugal.Centrifuge.Transports
 
         private async Task CleanupAsync(bool alreadyClosed = false)
         {
+            if (System.Threading.Interlocked.CompareExchange(ref _cleanupStarted, 1, 0) != 0) return;
             _logger?.LogDebug($"CleanupAsync called for stream {_streamId}, alreadyClosed: {alreadyClosed}");
             _isOpen = false;
             _openTcs?.TrySetCanceled();
@@ -419,8 +408,7 @@ namespace Centrifugal.Centrifuge.Transports
         /// <inheritdoc/>
         public void Dispose()
         {
-            if (_disposed) return;
-            _disposed = true;
+            if (System.Threading.Interlocked.CompareExchange(ref _disposed, 1, 0) != 0) return;
 
             _ = CloseAsync();
         }

--- a/src/Centrifugal.Centrifuge/Transports/BrowserWebSocketTransport.cs
+++ b/src/Centrifugal.Centrifuge/Transports/BrowserWebSocketTransport.cs
@@ -22,8 +22,9 @@ namespace Centrifugal.Centrifuge.Transports
         private IJSObjectReference? _jsModule;
         private DotNetObjectReference<BrowserWebSocketTransport>? _dotnetRef;
         private int _socketId;
-        private bool _disposed;
-        private bool _isOpen;
+        private int _disposed;
+        private int _cleanupStarted;
+        private volatile bool _isOpen;
         private TaskCompletionSource<bool>? _openTcs;
 
         /// <inheritdoc/>
@@ -208,6 +209,8 @@ namespace Centrifugal.Centrifuge.Transports
         public void OnOpen()
         {
             _logger?.LogDebug($"OnOpen called for socket {_socketId}");
+            // Discard stale callback if CleanupAsync already ran (e.g. OpenAsync timed out).
+            if (System.Threading.Interlocked.CompareExchange(ref _cleanupStarted, 0, 0) != 0) return;
             // Set _isOpen BEFORE firing events so handlers can use the transport immediately
             _isOpen = true;
             var result = _openTcs?.TrySetResult(true);
@@ -258,6 +261,7 @@ namespace Centrifugal.Centrifuge.Transports
         [JSInvokable]
         public void OnError(string message)
         {
+            if (System.Threading.Interlocked.CompareExchange(ref _cleanupStarted, 0, 0) != 0) return;
             Error?.Invoke(this, new Exception(message ?? "WebSocket error"));
         }
 
@@ -269,6 +273,7 @@ namespace Centrifugal.Centrifuge.Transports
         [JSInvokable]
         public void OnClose(object? codeObj, object? reasonObj)
         {
+            if (System.Threading.Interlocked.CompareExchange(ref _cleanupStarted, 0, 0) != 0) return;
             // Log directly via JavaScript to ensure it shows up
             _ = _jsRuntime.InvokeVoidAsync("console.log", "[C#] OnClose called with codeObj:", codeObj, "reasonObj:", reasonObj);
 
@@ -303,6 +308,7 @@ namespace Centrifugal.Centrifuge.Transports
 
         private async Task CleanupAsync(bool alreadyClosed = false)
         {
+            if (System.Threading.Interlocked.CompareExchange(ref _cleanupStarted, 1, 0) != 0) return;
             _logger?.LogDebug($"CleanupAsync called for socket {_socketId}, alreadyClosed: {alreadyClosed}");
             _isOpen = false;
             _openTcs?.TrySetCanceled();
@@ -361,8 +367,7 @@ namespace Centrifugal.Centrifuge.Transports
         /// <inheritdoc/>
         public void Dispose()
         {
-            if (_disposed) return;
-            _disposed = true;
+            if (System.Threading.Interlocked.CompareExchange(ref _disposed, 1, 0) != 0) return;
 
             _ = CloseAsync();
         }

--- a/src/Centrifugal.Centrifuge/Transports/HttpStreamTransport.cs
+++ b/src/Centrifugal.Centrifuge/Transports/HttpStreamTransport.cs
@@ -19,9 +19,10 @@ namespace Centrifugal.Centrifuge.Transports
         private readonly string _endpoint;
         private readonly HttpClient _httpClient;
         private readonly bool _ownsHttpClient;
+        private readonly object _openCloseLock = new object();
         private CancellationTokenSource? _receiveCts;
         private Task? _receiveTask;
-        private bool _disposed;
+        private int _disposed;
         private bool _isOpen;
 
         /// <inheritdoc/>
@@ -80,12 +81,17 @@ namespace Centrifugal.Centrifuge.Transports
                 throw new InvalidOperationException("Transport is already open");
             }
 
+            CancellationTokenSource? receiveCts = null;
             try
             {
                 var openedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-                _receiveCts = new CancellationTokenSource();
-                _receiveTask = ReceiveLoopAsync(initialData ?? Array.Empty<byte>(), openedTcs, _receiveCts.Token);
+                lock (_openCloseLock)
+                {
+                    _receiveCts = new CancellationTokenSource();
+                    receiveCts = _receiveCts;
+                }
+                _receiveTask = ReceiveLoopAsync(initialData ?? Array.Empty<byte>(), openedTcs, receiveCts.Token);
 
                 // Wait for the connection to open or timeout
                 using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -99,12 +105,10 @@ namespace Centrifugal.Centrifuge.Transports
 
                 // Propagate any exception the receive loop set on openedTcs (early HTTP failure, etc.)
                 await openedTcs.Task.ConfigureAwait(false);
-
-                _isOpen = true;
             }
             catch (Exception ex)
             {
-                _receiveCts?.Cancel();
+                receiveCts?.Cancel();
                 throw new CentrifugeException(CentrifugeErrorCodes.TransportClosed, "Failed to open HTTP stream connection", true, ex);
             }
         }
@@ -118,7 +122,13 @@ namespace Centrifugal.Centrifuge.Transports
         /// <inheritdoc/>
         public async Task SendEmulationAsync(byte[] data, string session, string node, string emulationEndpoint, CancellationToken cancellationToken = default)
         {
-            if (!_isOpen)
+            if (System.Threading.Interlocked.CompareExchange(ref _disposed, 0, 0) != 0)
+            {
+                throw new CentrifugeException(CentrifugeErrorCodes.TransportClosed, "HTTP stream transport is disposed");
+            }
+            bool isOpen;
+            lock (_openCloseLock) { isOpen = _isOpen; }
+            if (!isOpen)
             {
                 throw new CentrifugeException(CentrifugeErrorCodes.TransportClosed, "HTTP stream transport is not open");
             }
@@ -139,7 +149,7 @@ namespace Centrifugal.Centrifuge.Transports
                 using var content = new ByteArrayContent(requestBytes);
                 content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/octet-stream");
 
-                var response = await _httpClient.PostAsync(emulationEndpoint, content, cancellationToken).ConfigureAwait(false);
+                using var response = await _httpClient.PostAsync(emulationEndpoint, content, cancellationToken).ConfigureAwait(false);
                 response.EnsureSuccessStatusCode();
             }
             catch (Exception ex)
@@ -151,11 +161,17 @@ namespace Centrifugal.Centrifuge.Transports
         /// <inheritdoc/>
         public async Task CloseAsync()
         {
-            if (!_isOpen) return;
+            CancellationTokenSource? cts;
+            lock (_openCloseLock)
+            {
+                if (!_isOpen && _receiveCts == null) return;
+                cts = _receiveCts;
+                _isOpen = false;
+            }
 
             try
             {
-                _receiveCts?.Cancel();
+                cts?.Cancel();
 
                 if (_receiveTask != null)
                 {
@@ -166,14 +182,11 @@ namespace Centrifugal.Centrifuge.Transports
             {
                 // Ignore errors during close
             }
-            finally
-            {
-                _isOpen = false;
-            }
         }
 
         private async Task ReceiveLoopAsync(byte[] initialData, TaskCompletionSource<bool> openedTcs, CancellationToken cancellationToken)
         {
+            bool connectionOpened = false;
             try
             {
                 // Send initial POST request with varint-delimited connect command
@@ -189,80 +202,74 @@ namespace Centrifugal.Centrifuge.Transports
                 request.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/octet-stream"));
                 request.Headers.ConnectionClose = false; // Keep connection alive for streaming
 
-                var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                     .ConfigureAwait(false);
 
-                // Check for HTTP errors and map to appropriate close codes
+                // Non-2xx response: propagate via openedTcs so OpenAsync throws and the normal
+                // reconnect path handles retrying.  Do NOT fire Closed — OnTransportClosed is
+                // already registered and firing it would cause a duplicate reconnect.
                 if (!response.IsSuccessStatusCode)
                 {
                     int statusCode = (int)response.StatusCode;
-                    int closeCode;
-                    string errorReason = $"http error {statusCode}";
-
-                    // Map specific HTTP 4xx client errors to BadProtocol (non-reconnectable)
-                    // Only 400, 401, 403, 404, 405 are considered permanent client errors
-                    if (statusCode == 400 || statusCode == 401 || statusCode == 403 ||
-                        statusCode == 404 || statusCode == 405)
-                    {
-                        closeCode = CentrifugeDisconnectedCodes.BadProtocol;
-                    }
-                    else
-                    {
-                        // All other errors use TransportClosed (reconnectable)
-                        closeCode = CentrifugeConnectingCodes.TransportClosed;
-                    }
-
-                    // Signal the early failure to OpenAsync so it doesn't wait for the 10s timeout
-                    openedTcs.TrySetException(new CentrifugeException(CentrifugeErrorCodes.TransportClosed, errorReason, true));
-                    Closed?.Invoke(this, new TransportClosedEventArgs(code: closeCode, reason: errorReason));
+                    openedTcs.TrySetException(new CentrifugeException(CentrifugeErrorCodes.TransportClosed, $"http error {statusCode}", true));
                     return;
                 }
 
-
-                // Connection established successfully
+                connectionOpened = true;
+                lock (_openCloseLock) { _isOpen = true; }
                 openedTcs.TrySetResult(true);
                 Opened?.Invoke(this, EventArgs.Empty);
 
                 using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
                 byte[] tempBuffer = new byte[8192];
 
-                // Read varint-delimited messages from the stream
                 while (!cancellationToken.IsCancellationRequested)
                 {
                     byte[]? message = await VarintCodec.ReadDelimitedMessageAsync(stream, tempBuffer, cancellationToken).ConfigureAwait(false);
-                    if (message == null)
-                    {
-                        break;
-                    }
-
-                    // Invoke MessageReceived event synchronously
-                    // Exceptions will propagate to outer catch, firing Error and Closed events
+                    if (message == null) break;
                     MessageReceived?.Invoke(this, message);
+                }
+
+                // Server closed the stream (EOF) — fire Closed so the client can reconnect
+                if (!cancellationToken.IsCancellationRequested)
+                {
+                    Closed?.Invoke(this, new TransportClosedEventArgs());
                 }
             }
             catch (OperationCanceledException)
             {
-                // Normal cancellation — unblock OpenAsync if it's still waiting
                 openedTcs.TrySetCanceled();
             }
             catch (Exception ex)
             {
-                // Unblock OpenAsync if the failure happened before the connection opened
-                openedTcs.TrySetException(ex);
-                Error?.Invoke(this, ex);
-                // Close code should have been set by earlier status check if it was an HTTP error
-                Closed?.Invoke(this, new TransportClosedEventArgs(exception: ex));
+                if (connectionOpened)
+                {
+                    // Post-open failure: inform the client the transport died
+                    Error?.Invoke(this, ex);
+                    Closed?.Invoke(this, new TransportClosedEventArgs(exception: ex));
+                }
+                else
+                {
+                    // Pre-open failure: propagate via openedTcs so OpenAsync throws;
+                    // the caller's reconnect path handles retrying without a duplicate Closed
+                    openedTcs.TrySetException(ex);
+                }
             }
         }
 
         /// <inheritdoc/>
         public void Dispose()
         {
-            if (_disposed) return;
-            _disposed = true;
+            if (System.Threading.Interlocked.CompareExchange(ref _disposed, 1, 0) != 0) return;
 
-            _receiveCts?.Cancel();
-            _receiveCts?.Dispose();
+            CancellationTokenSource? cts;
+            lock (_openCloseLock)
+            {
+                cts = _receiveCts;
+                _isOpen = false;
+            }
+            cts?.Cancel();
+            cts?.Dispose();
 
             if (_ownsHttpClient)
             {

--- a/src/Centrifugal.Centrifuge/Transports/WebSocketTransport.cs
+++ b/src/Centrifugal.Centrifuge/Transports/WebSocketTransport.cs
@@ -18,7 +18,7 @@ namespace Centrifugal.Centrifuge.Transports
         private CancellationTokenSource? _receiveCts;
         private Task? _receiveTask;
         private readonly SemaphoreSlim _sendLock = new SemaphoreSlim(1, 1);
-        private bool _disposed;
+        private int _disposed;
 
         /// <inheritdoc/>
         public CentrifugeTransportType Type => CentrifugeTransportType.WebSocket;
@@ -89,14 +89,14 @@ namespace Centrifugal.Centrifuge.Transports
         /// <inheritdoc/>
         public async Task SendAsync(byte[] data, CancellationToken cancellationToken = default)
         {
-            if (_webSocket == null || _webSocket.State != WebSocketState.Open)
-            {
-                throw new CentrifugeException(CentrifugeErrorCodes.TransportClosed, "WebSocket is not open");
-            }
-
             await _sendLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
+                if (_webSocket == null || _webSocket.State != WebSocketState.Open)
+                {
+                    throw new CentrifugeException(CentrifugeErrorCodes.TransportClosed, "WebSocket is not open");
+                }
+
                 await _webSocket.SendAsync(
                     new ArraySegment<byte>(data),
                     WebSocketMessageType.Binary,
@@ -121,18 +121,22 @@ namespace Centrifugal.Centrifuge.Transports
         {
             if (_webSocket == null) return;
 
+            // Capture fields as locals to avoid racing with concurrent Dispose().
+            var cts = _receiveCts;
+            var receiveTask = _receiveTask;
+
             // Cancel the receive loop and wait for it to fully exit BEFORE issuing
             // any further socket operations. ClientWebSocket allows at most one
             // outstanding ReceiveAsync; calling CloseAsync (which reads to wait
             // for the close ack) while ReceiveLoopAsync is still in ReceiveAsync
             // produces undefined behaviour and has been observed to hang on Linux.
-            _receiveCts?.Cancel();
+            try { cts?.Cancel(); } catch (ObjectDisposedException) { }
 
-            if (_receiveTask != null)
+            if (receiveTask != null)
             {
                 try
                 {
-                    await _receiveTask.ConfigureAwait(false);
+                    await receiveTask.ConfigureAwait(false);
                 }
                 catch
                 {
@@ -147,8 +151,8 @@ namespace Centrifugal.Centrifuge.Transports
                     // CloseOutputAsync only sends the close frame; it does not block
                     // waiting for a server ack. The connection is being torn down
                     // anyway, so we don't need a clean handshake.
-                    using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-                    await _webSocket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "Client disconnect", cts.Token)
+                    using var closeCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+                    await _webSocket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "Client disconnect", closeCts.Token)
                         .ConfigureAwait(false);
                 }
             }
@@ -165,10 +169,13 @@ namespace Centrifugal.Centrifuge.Transports
         {
             var buffer = ArrayPool<byte>.Shared.Rent(16 * 1024);
             var ms = new MemoryStream();
+            // Capture the socket as a local so a concurrent Dispose nulling _webSocket
+            // (future-proofing) can't cause NREs mid-loop.
+            var webSocket = _webSocket;
 
             try
             {
-                while (!cancellationToken.IsCancellationRequested && _webSocket != null)
+                while (!cancellationToken.IsCancellationRequested && webSocket != null)
                 {
                     WebSocketReceiveResult result;
                     ms.SetLength(0);
@@ -176,7 +183,7 @@ namespace Centrifugal.Centrifuge.Transports
                     // Read the complete WebSocket message
                     do
                     {
-                        result = await _webSocket.ReceiveAsync(
+                        result = await webSocket.ReceiveAsync(
                             new ArraySegment<byte>(buffer),
                             cancellationToken
                         ).ConfigureAwait(false);
@@ -227,8 +234,7 @@ namespace Centrifugal.Centrifuge.Transports
         /// <inheritdoc/>
         public void Dispose()
         {
-            if (_disposed) return;
-            _disposed = true;
+            if (System.Threading.Interlocked.CompareExchange(ref _disposed, 1, 0) != 0) return;
 
             _receiveCts?.Cancel();
             _receiveCts?.Dispose();

--- a/tests/Centrifugal.Centrifuge.Tests/IntegrationTests.cs
+++ b/tests/Centrifugal.Centrifuge.Tests/IntegrationTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Centrifugal.Centrifuge;
 using Xunit;
@@ -737,6 +738,299 @@ namespace Centrifugal.Centrifuge.Tests
 
         [Theory]
         [MemberData(nameof(GetCentrifugeTransportEndpoints))]
+        public async Task SubscriptionRetriesAfterMultipleGetTokenErrors(CentrifugeTransportType transport, string endpoint)
+        {
+            // GetToken throws 3 times, succeeds on 4th call.
+            // Bug: ScheduleResubscribeAsync doesn't catch errors from its inner retry, so
+            // after the 2nd failure the subscription is permanently stuck in Subscribing state.
+            int callCount = 0;
+            var subOptions = new CentrifugeSubscriptionOptions
+            {
+                GetToken = async (channel) =>
+                {
+                    Interlocked.Increment(ref callCount);
+                    if (callCount < 4)
+                        throw new Exception("token error");
+                    return ""; // insecure mode — empty token accepted
+                },
+                MinResubscribeDelay = TimeSpan.FromMilliseconds(1),
+                MaxResubscribeDelay = TimeSpan.FromMilliseconds(50)
+            };
+
+            using var client = CreateClient(transport, endpoint);
+            client.Connect();
+            await client.ReadyAsync();
+
+            var sub = client.NewSubscription("test-retry-multi", subOptions);
+            var subscribedTcs = new TaskCompletionSource<bool>();
+            sub.Subscribed += (_, _) => subscribedTcs.TrySetResult(true);
+            sub.Subscribe();
+
+            // Without fix: stuck in Subscribing after 2nd GetToken failure → times out
+            // With fix: retries until success on 4th call
+            await subscribedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Equal(CentrifugeSubscriptionState.Subscribed, sub.State);
+            Assert.Equal(4, callCount);
+
+            client.Disconnect();
+        }
+
+        [Theory]
+        [MemberData(nameof(GetCentrifugeTransportEndpoints))]
+        public async Task HandleSubscribeTimeout_TriggersCleanReconnectAndResubscribe(CentrifugeTransportType transport, string endpoint)
+        {
+            using var client = CreateClient(transport, endpoint, new CentrifugeClientOptions
+            {
+                MinReconnectDelay = TimeSpan.FromMilliseconds(1),
+                MaxReconnectDelay = TimeSpan.FromMilliseconds(50)
+            });
+            client.Connect();
+            await client.ReadyAsync();
+
+            var sub = client.NewSubscription("test-sub-timeout");
+            sub.Subscribe();
+            await sub.ReadyAsync();
+
+            var connectedTcs = new TaskCompletionSource<bool>();
+            var subscribedTcs = new TaskCompletionSource<bool>();
+            client.Connected += (_, _) => connectedTcs.TrySetResult(true);
+            sub.Subscribed += (_, _) => subscribedTcs.TrySetResult(true);
+
+            // Directly invoke the internal method to simulate subscribe timeout path.
+            // Bug: this calls StartConnectingAsync (opens transport) then CleanupTransportAsync
+            // (destroys it), leaving OnTransportOpened racing with ScheduleReconnectAsync.
+            // Fix: directly transitions state without creating a throwaway transport.
+            await client.HandleSubscribeTimeoutAsync();
+
+            await connectedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await subscribedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Equal(CentrifugeClientState.Connected, client.State);
+            Assert.Equal(CentrifugeSubscriptionState.Subscribed, sub.State);
+
+            client.Disconnect();
+        }
+
+        [Theory]
+        [MemberData(nameof(GetCentrifugeTransportEndpoints))]
+        public async Task NoPing_TriggersResubscribeAfterReconnect(CentrifugeTransportType transport, string endpoint)
+        {
+            using var client = CreateClient(transport, endpoint, new CentrifugeClientOptions
+            {
+                MinReconnectDelay = TimeSpan.FromMilliseconds(1),
+                MaxReconnectDelay = TimeSpan.FromMilliseconds(50)
+            });
+            client.Connect();
+            await client.ReadyAsync();
+
+            var sub = client.NewSubscription("test-noping-resubscribe");
+            sub.Subscribe();
+            await sub.ReadyAsync();
+
+            // Listen for the Subscribing event — if the bug is present, NoPing reconnect
+            // goes through StartConnectingAsync which skips MoveToSubscribing, so the
+            // subscription stays in Subscribed state and never fires Subscribing again.
+            var subscribingTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var subscribedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            sub.Subscribing += (_, _) => subscribingTcs.TrySetResult(true);
+            sub.Subscribed += (_, _) => subscribedTcs.TrySetResult(true);
+
+            // Simulate what the ping timer fires when server stops pinging.
+            await client.HandleNoPingAsync();
+
+            // Subscription must cycle through Subscribing → Subscribed on the fresh connection.
+            // Without the fix this times out because subscriptions are never moved to Subscribing.
+            await subscribingTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await subscribedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Equal(CentrifugeClientState.Connected, client.State);
+            Assert.Equal(CentrifugeSubscriptionState.Subscribed, sub.State);
+
+            client.Disconnect();
+        }
+
+        [Theory]
+        [MemberData(nameof(GetCentrifugeTransportEndpoints))]
+        public async Task ResubscribeAsync_GetTokenUnauthorized_DoesNotDeadlock(CentrifugeTransportType transport, string endpoint)
+        {
+            // Bug: ResubscribeAsync holds _stateLock while awaiting StartSubscribingAsync.
+            // When GetToken throws CentrifugeUnauthorizedException, SetUnsubscribedAsync
+            // tries to acquire the same _stateLock → deadlock.
+            // Fix: replace _stateLock hold with a quick _stateChangeLock check only.
+            int callCount = 0;
+            var subOptions = new CentrifugeSubscriptionOptions
+            {
+                GetToken = async (channel) =>
+                {
+                    int n = Interlocked.Increment(ref callCount);
+                    if (n >= 2)
+                        throw new CentrifugeUnauthorizedException("unauthorized");
+                    return ""; // insecure mode — empty token accepted on first call
+                }
+            };
+
+            using var client = CreateClient(transport, endpoint);
+            client.Connect();
+            await client.ReadyAsync();
+
+            var sub = client.NewSubscription("test-resubscribe-deadlock", subOptions);
+            sub.Subscribe();
+            await sub.ReadyAsync();
+            Assert.Equal(CentrifugeSubscriptionState.Subscribed, sub.State);
+
+            // Without fix: deadlocks → never returns within 3 seconds
+            // With fix: SetUnsubscribedAsync runs, sub becomes Unsubscribed
+            await sub.ResubscribeAsync().WaitAsync(TimeSpan.FromSeconds(3));
+
+            Assert.Equal(CentrifugeSubscriptionState.Unsubscribed, sub.State);
+            client.Disconnect();
+        }
+
+        [Theory]
+        [MemberData(nameof(GetCentrifugeTransportEndpoints))]
+        public async Task MoveToSubscribing_CancelsResubscribeTimer_PreventsDuplicateSubscribeOnReconnect(CentrifugeTransportType transport, string endpoint)
+        {
+            // Bug: MoveToSubscribing only cancels _resubscribeCts for Subscribed→Subscribing.
+            // If already Subscribing (GetToken failed, resubscribe timer pending), the cancel
+            // is skipped and the stale timer fires calling GetToken again, causing an unwanted
+            // Unsubscribed event when that call throws Unauthorized.
+            // Fix: cancel _resubscribeCts for any non-Unsubscribed state.
+            int callCount = 0;
+            var firstGetTokenTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var subOptions = new CentrifugeSubscriptionOptions
+            {
+                GetToken = async (channel) =>
+                {
+                    int n = Interlocked.Increment(ref callCount);
+                    firstGetTokenTcs.TrySetResult(true);
+                    if (n == 1) throw new Exception("transient token error"); // → ScheduleResubscribeAsync
+                    throw new CentrifugeUnauthorizedException("unauthorized"); // stale timer fires this
+                },
+                MinResubscribeDelay = TimeSpan.FromMilliseconds(300),
+                MaxResubscribeDelay = TimeSpan.FromMilliseconds(300)
+            };
+
+            using var client = CreateClient(transport, endpoint);
+            client.Connect();
+            await client.ReadyAsync();
+
+            var sub = client.NewSubscription("test-stale-timer", subOptions);
+            var unsubscribedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            sub.Unsubscribed += (_, _) => unsubscribedTcs.TrySetResult(true);
+
+            sub.Subscribe();
+
+            // Wait until GetToken(1) has actually been invoked — the 300ms resubscribe
+            // timer is now guaranteed to be running.
+            await firstGetTokenTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await Task.Delay(20); // brief pause so Task.Delay inside ScheduleResubscribeAsync has started
+
+            // Directly call MoveToSubscribing (simulates what transport reconnect code does
+            // when the subscription is already Subscribing).
+            // Without fix: state != Subscribed → returns early, _resubscribeCts NOT cancelled.
+            // With fix: cancels _resubscribeCts so the 300ms timer is interrupted.
+            sub.MoveToSubscribing(CentrifugeConnectingCodes.TransportClosed, "transport closed");
+
+            // Wait well past the 300ms resubscribe timer
+            await Task.Delay(500);
+
+            // Without fix: stale timer fired → GetToken(2) → Unauthorized → Unsubscribed
+            // With fix: stale timer cancelled → GetToken(2) never called
+            Assert.False(unsubscribedTcs.Task.IsCompleted, "stale resubscribe timer fired after MoveToSubscribing");
+            Assert.Equal(1, callCount);
+
+            client.Disconnect();
+        }
+
+        [Theory]
+        [MemberData(nameof(GetCentrifugeTransportEndpoints))]
+        public async Task SendSubscribeCommand_DoesNotSendAfterUnsubscribeDuringGetToken(CentrifugeTransportType transport, string endpoint)
+        {
+            // Bug: SendSubscribeCommandAsync has no state re-check after awaiting GetToken.
+            // If Unsubscribe() is called while GetToken awaits, the method continues and
+            // sends a Subscribe command to the server despite the sub being Unsubscribed,
+            // creating a phantom server-side subscription that delivers publications to
+            // the client after the client has locally unsubscribed.
+            //
+            // Fix: add lock(_stateChangeLock) { if (_state != Subscribing) return; } after
+            // the GetToken await.
+
+            var getTokenGate = new SemaphoreSlim(0, 1);
+            var getTokenCalledTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            int callCount = 0;
+
+            var channelName = $"test-statefence-{Guid.NewGuid():N}";
+
+            var subOptions = new CentrifugeSubscriptionOptions
+            {
+                GetToken = async (channel) =>
+                {
+                    int n = Interlocked.Increment(ref callCount);
+                    if (n >= 2)
+                    {
+                        getTokenCalledTcs.TrySetResult(true);
+                        await getTokenGate.WaitAsync(); // block until released
+                    }
+                    return ""; // insecure mode — empty token accepted
+                }
+            };
+
+            using var client = CreateClient(transport, endpoint);
+            client.Connect();
+            await client.ReadyAsync();
+
+            var sub = client.NewSubscription(channelName, subOptions);
+            var publicationReceived = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            sub.Publication += (_, _) => publicationReceived.TrySetResult(true);
+
+            var unsubscribedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            sub.Unsubscribed += (_, _) => unsubscribedTcs.TrySetResult(true);
+
+            // GetToken(1) returns "" → sub becomes Subscribed on server
+            sub.Subscribe();
+            await sub.ReadyAsync();
+            Assert.Equal(CentrifugeSubscriptionState.Subscribed, sub.State);
+
+            // Trigger resubscribe → SendSubscribeCommandAsync → GetToken(2) blocks on gate
+            _ = sub.ResubscribeAsync();
+            await getTokenCalledTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            // While GetToken(2) is blocked, unsubscribe — sets local state to Unsubscribed
+            // and schedules an Unsubscribe command to be sent to the server
+            sub.Unsubscribe();
+            await unsubscribedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            // Give the async Unsubscribe command enough time to reach the server so that
+            // any phantom Subscribe (the bug) arrives AFTER Unsubscribe, making the server
+            // route publications to us (proving the bug).
+            await Task.Delay(500);
+
+            // Release the gate — without the fix, SendSubscribeCommandAsync skips the state
+            // check and sends a Subscribe to the server (phantom subscription)
+            getTokenGate.Release();
+            await Task.Delay(500); // let any phantom Subscribe be processed by the server
+
+            // Publish via the server HTTP API
+            using var httpClient = new System.Net.Http.HttpClient();
+            var publishRequest = new { channel = channelName, data = new { text = "hello" } };
+            var requestJson = System.Text.Json.JsonSerializer.Serialize(publishRequest);
+            var content = new System.Net.Http.StringContent(requestJson, Encoding.UTF8, "application/json");
+            var response = await httpClient.PostAsync("http://localhost:8000/api/publish", content);
+            response.EnsureSuccessStatusCode();
+
+            await Task.Delay(300);
+
+            // Without fix: phantom Subscribe → server routes publication → Publication event fires
+            // With fix: no Subscribe sent after state check → server does not route → no event
+            Assert.False(publicationReceived.Task.IsCompleted,
+                "received publication despite being Unsubscribed — phantom subscribe was sent");
+
+            client.Disconnect();
+        }
+
+        [Theory]
+        [MemberData(nameof(GetCentrifugeTransportEndpoints))]
         public async Task PresenceReturnsCurrentClient(CentrifugeTransportType transport, string endpoint)
         {
             using var client1 = CreateClient(transport, endpoint);
@@ -805,6 +1099,638 @@ namespace Centrifugal.Centrifuge.Tests
             subscription2.Unsubscribe();
             client1.Disconnect();
             client2.Disconnect();
+        }
+
+        [Theory]
+        [MemberData(nameof(GetCentrifugeTransportEndpoints))]
+        public async Task HandleNoPing_AfterDisconnect_DoesNotSpuriouslyReconnect(CentrifugeTransportType transport, string endpoint)
+        {
+            // Bug 21: HandleNoPingAsync checks _state == Disconnected outside _stateChangeLock.
+            // Race: Disconnect() sets state=Disconnected between the check and SetState(Connecting),
+            // causing HandleNoPingAsync to overwrite Disconnected with Connecting and trigger a
+            // spurious reconnect attempt.
+            // Fix: both check and SetState are inside lock(_stateChangeLock).
+            //
+            // This test fires both operations concurrently across many iterations to expose the race.
+            // With the fix every iteration ends in Disconnected; without it the test is flaky.
+            for (int i = 0; i < 50; i++)
+            {
+                using var client = CreateClient(transport, endpoint, new CentrifugeClientOptions
+                {
+                    MinReconnectDelay = TimeSpan.FromSeconds(60),
+                    MaxReconnectDelay = TimeSpan.FromSeconds(60),
+                });
+                client.Connect();
+                await client.ReadyAsync();
+
+                var spuriousConnecting = false;
+                var disconnectedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                client.Disconnected += (_, _) => disconnectedTcs.TrySetResult(true);
+                client.Connecting += (_, _) =>
+                {
+                    if (disconnectedTcs.Task.IsCompleted) spuriousConnecting = true;
+                };
+
+                await Task.WhenAll(
+                    client.HandleNoPingAsync(),
+                    Task.Run(() => client.Disconnect())
+                );
+
+                await disconnectedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+                await Task.Delay(50); // let any spurious ScheduleReconnectAsync start
+
+                Assert.False(spuriousConnecting, $"iteration {i}: spurious Connecting after Disconnect");
+                Assert.Equal(CentrifugeClientState.Disconnected, client.State);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetCentrifugeTransportEndpoints))]
+        public async Task HandleSubscribeTimeout_AfterDisconnect_DoesNotSpuriouslyReconnect(CentrifugeTransportType transport, string endpoint)
+        {
+            // Bug 22: same unlocked race in HandleSubscribeTimeoutAsync. Fix: same lock pattern.
+            for (int i = 0; i < 50; i++)
+            {
+                using var client = CreateClient(transport, endpoint, new CentrifugeClientOptions
+                {
+                    MinReconnectDelay = TimeSpan.FromSeconds(60),
+                    MaxReconnectDelay = TimeSpan.FromSeconds(60),
+                });
+                client.Connect();
+                await client.ReadyAsync();
+
+                var spuriousConnecting = false;
+                var disconnectedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                client.Disconnected += (_, _) => disconnectedTcs.TrySetResult(true);
+                client.Connecting += (_, _) =>
+                {
+                    if (disconnectedTcs.Task.IsCompleted) spuriousConnecting = true;
+                };
+
+                await Task.WhenAll(
+                    client.HandleSubscribeTimeoutAsync(),
+                    Task.Run(() => client.Disconnect())
+                );
+
+                await disconnectedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+                await Task.Delay(50);
+
+                Assert.False(spuriousConnecting, $"iteration {i}: spurious Connecting after Disconnect");
+                Assert.Equal(CentrifugeClientState.Disconnected, client.State);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetCentrifugeTransportEndpoints))]
+        public async Task HandleUnsubscribeError_AfterDisconnect_DoesNotSpuriouslyReconnect(CentrifugeTransportType transport, string endpoint)
+        {
+            // Bug 23: same unlocked race in HandleUnsubscribeErrorAsync. Fix: same lock pattern.
+            for (int i = 0; i < 50; i++)
+            {
+                using var client = CreateClient(transport, endpoint, new CentrifugeClientOptions
+                {
+                    MinReconnectDelay = TimeSpan.FromSeconds(60),
+                    MaxReconnectDelay = TimeSpan.FromSeconds(60),
+                });
+                client.Connect();
+                await client.ReadyAsync();
+
+                var spuriousConnecting = false;
+                var disconnectedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                client.Disconnected += (_, _) => disconnectedTcs.TrySetResult(true);
+                client.Connecting += (_, _) =>
+                {
+                    if (disconnectedTcs.Task.IsCompleted) spuriousConnecting = true;
+                };
+
+                await Task.WhenAll(
+                    client.HandleUnsubscribeErrorAsync(),
+                    Task.Run(() => client.Disconnect())
+                );
+
+                await disconnectedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+                await Task.Delay(50);
+
+                Assert.False(spuriousConnecting, $"iteration {i}: spurious Connecting after Disconnect");
+                Assert.Equal(CentrifugeClientState.Disconnected, client.State);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetCentrifugeTransportEndpoints))]
+        public async Task RefreshConnectionToken_DoesNotRefreshAfterDisconnectDuringGetToken(CentrifugeTransportType transport, string endpoint)
+        {
+            // Bug 26: RefreshConnectionTokenAsync has no state re-check after awaiting GetToken.
+            // If Disconnect() is called while GetToken awaits, the method continues and sends a
+            // Refresh command despite the client being Disconnected.
+            // Fix: lock(_stateChangeLock) { if (_state != Connected) return; } after the await.
+            var getTokenGate = new SemaphoreSlim(0, 1);
+            var getTokenCalledTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            int callCount = 0;
+
+            var options = new CentrifugeClientOptions
+            {
+                GetToken = async () =>
+                {
+                    int n = Interlocked.Increment(ref callCount);
+                    if (n >= 2)
+                    {
+                        getTokenCalledTcs.TrySetResult(true);
+                        await getTokenGate.WaitAsync(); // block until released
+                    }
+                    return ""; // insecure mode — empty token on first call
+                }
+            };
+
+            using var client = CreateClient(transport, endpoint, options);
+            client.Connect();
+            await client.ReadyAsync();
+            Assert.Equal(CentrifugeClientState.Connected, client.State);
+
+            var disconnectedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            client.Disconnected += (_, _) => disconnectedTcs.TrySetResult(true);
+
+            // Trigger the refresh path directly — GetToken(2) will block on the gate
+            _ = client.RefreshConnectionTokenAsync();
+            await getTokenCalledTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            // Disconnect while GetToken(2) is blocked — sets local state to Disconnected
+            client.Disconnect();
+            await disconnectedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Equal(CentrifugeClientState.Disconnected, client.State);
+
+            // Release the gate — without fix, RefreshConnectionTokenAsync skips the state
+            // check and sends a Refresh command over an already-closed transport
+            getTokenGate.Release();
+            await Task.Delay(300); // let any phantom Refresh attempt complete
+
+            // Client must remain Disconnected; no reconnect triggered by the phantom Refresh
+            Assert.Equal(CentrifugeClientState.Disconnected, client.State);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetCentrifugeTransportEndpoints))]
+        public async Task RefreshSubscriptionToken_DoesNotRefreshAfterUnsubscribeDuringGetToken(CentrifugeTransportType transport, string endpoint)
+        {
+            // Bug 27: RefreshTokenAsync (subscription) has no state re-check after GetToken.
+            // If Unsubscribe() is called while GetToken awaits, the method continues and sends
+            // a SubRefresh command despite the subscription being Unsubscribed.
+            // Fix: lock(_stateChangeLock) { if (_state != Subscribed) return; } after the await.
+            var getTokenGate = new SemaphoreSlim(0, 1);
+            var getTokenCalledTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            int callCount = 0;
+
+            var channelName = $"test-subrefresh-fence-{Guid.NewGuid():N}";
+            var subOptions = new CentrifugeSubscriptionOptions
+            {
+                GetToken = async (channel) =>
+                {
+                    int n = Interlocked.Increment(ref callCount);
+                    if (n >= 2)
+                    {
+                        getTokenCalledTcs.TrySetResult(true);
+                        await getTokenGate.WaitAsync();
+                    }
+                    return ""; // insecure mode
+                }
+            };
+
+            using var client = CreateClient(transport, endpoint);
+            client.Connect();
+            await client.ReadyAsync();
+
+            var sub = client.NewSubscription(channelName, subOptions);
+            sub.Subscribe();
+            await sub.ReadyAsync();
+            Assert.Equal(CentrifugeSubscriptionState.Subscribed, sub.State);
+
+            var unsubscribedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            sub.Unsubscribed += (_, _) => unsubscribedTcs.TrySetResult(true);
+
+            // Trigger the token refresh path directly — GetToken(2) blocks
+            _ = sub.RefreshTokenAsync();
+            await getTokenCalledTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            // Unsubscribe while GetToken(2) is blocked
+            sub.Unsubscribe();
+            await unsubscribedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Equal(CentrifugeSubscriptionState.Unsubscribed, sub.State);
+
+            // Release the gate — without fix, RefreshTokenAsync skips the state check and
+            // sends a SubRefresh command over the server-side unsubscribed channel
+            getTokenGate.Release();
+            await Task.Delay(300);
+
+            // Subscription must remain Unsubscribed
+            Assert.Equal(CentrifugeSubscriptionState.Unsubscribed, sub.State);
+
+            client.Disconnect();
+        }
+
+        [Theory]
+        [MemberData(nameof(GetCentrifugeTransportEndpoints))]
+        public async Task ResubscribeAsync_AfterUnsubscribe_DoesNotOverwriteUnsubscribedState(CentrifugeTransportType transport, string endpoint)
+        {
+            // Bug 28: StartSubscribingAsync called SetState(Subscribing) without _stateChangeLock.
+            // Race: ResubscribeAsync (server temp-unsub path) releases the lock after checking state,
+            // then Unsubscribe() runs and sets state to Unsubscribed, then StartSubscribingAsync
+            // overwrites Unsubscribed with Subscribing — subscription stuck in wrong state.
+            // Fix: SetState(Subscribing) is now inside lock(_stateChangeLock) with re-check.
+            //
+            // Run 50 concurrent iterations. With the fix every iteration ends Unsubscribed.
+            for (int i = 0; i < 50; i++)
+            {
+                using var client = CreateClient(transport, endpoint, new CentrifugeClientOptions
+                {
+                    MinReconnectDelay = TimeSpan.FromSeconds(60),
+                    MaxReconnectDelay = TimeSpan.FromSeconds(60),
+                });
+                client.Connect();
+                await client.ReadyAsync();
+
+                var sub = client.NewSubscription($"test-resubscribe-race-{i}");
+                sub.Subscribe();
+                await sub.ReadyAsync();
+
+                var unsubscribedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                sub.Unsubscribed += (_, _) => unsubscribedTcs.TrySetResult(true);
+
+                // Fire both concurrently: server-side resubscribe path vs. user unsubscribe.
+                // Without fix: StartSubscribingAsync may overwrite the Unsubscribed state set by
+                // SetUnsubscribedAsync, leaving the subscription stuck in Subscribing.
+                await Task.WhenAll(
+                    sub.ResubscribeAsync(),
+                    Task.Run(() => sub.Unsubscribe())
+                );
+
+                await unsubscribedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+                await Task.Delay(50); // let any spurious subscribe attempt start
+
+                Assert.Equal(CentrifugeSubscriptionState.Unsubscribed, sub.State);
+                client.Disconnect();
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetCentrifugeTransportEndpoints))]
+        public async Task ResubscribeAsync_DoesNotSendDuplicateSubscribe_WhenInflightConcurrent(CentrifugeTransportType transport, string endpoint)
+        {
+            // Bug 29: StartSubscribingAsync called SendSubscribeCommandAsync directly, bypassing
+            // the _inflight guard. A concurrent SendSubscribeCommandsAsync from a reconnect batch
+            // could also be calling SendSubscribeCommandAsync, resulting in two simultaneous
+            // Subscribe commands for the same channel.
+            // Fix: StartSubscribingAsync now delegates to SendSubscribeIfNeededAsync which holds
+            // _inflight, preventing the duplicate.
+            //
+            // Test: call ResubscribeAsync while GetToken is blocked, then Unsubscribe while blocked.
+            // With the _inflight + state-fence combo, only one subscribe reaches the server and
+            // no phantom subscribe is sent after Unsubscribe.
+            var getTokenGate = new SemaphoreSlim(0, 1);
+            var getTokenCalledTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            int callCount = 0;
+            var channelName = $"test-resubscribe-inflight-{Guid.NewGuid():N}";
+
+            var subOptions = new CentrifugeSubscriptionOptions
+            {
+                GetToken = async (channel) =>
+                {
+                    int n = Interlocked.Increment(ref callCount);
+                    if (n >= 2)
+                    {
+                        getTokenCalledTcs.TrySetResult(true);
+                        await getTokenGate.WaitAsync();
+                    }
+                    return ""; // insecure mode
+                }
+            };
+
+            using var client = CreateClient(transport, endpoint);
+            client.Connect();
+            await client.ReadyAsync();
+
+            var sub = client.NewSubscription(channelName, subOptions);
+            sub.Subscribe();
+            await sub.ReadyAsync();
+
+            var publicationReceived = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            sub.Publication += (_, _) => publicationReceived.TrySetResult(true);
+
+            var unsubscribedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            sub.Unsubscribed += (_, _) => unsubscribedTcs.TrySetResult(true);
+
+            // Trigger resubscribe path → GetToken(2) blocks
+            _ = sub.ResubscribeAsync();
+            await getTokenCalledTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            // Unsubscribe while GetToken(2) is blocked
+            sub.Unsubscribe();
+            await unsubscribedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            // Give server time to process any pending Unsubscribe command
+            await Task.Delay(500);
+
+            // Release gate — without fix, a duplicate Subscribe could race through
+            getTokenGate.Release();
+            await Task.Delay(500);
+
+            // Publish to channel — no Publication event should fire (not subscribed)
+            using var httpClient = new System.Net.Http.HttpClient();
+            var publishRequest = new { channel = channelName, data = new { text = "hello" } };
+            var requestJson = System.Text.Json.JsonSerializer.Serialize(publishRequest);
+            var content = new System.Net.Http.StringContent(requestJson, Encoding.UTF8, "application/json");
+            var response = await httpClient.PostAsync("http://localhost:8000/api/publish", content);
+            response.EnsureSuccessStatusCode();
+
+            await Task.Delay(300);
+
+            Assert.False(publicationReceived.Task.IsCompleted,
+                "received publication after Unsubscribe — duplicate Subscribe was sent");
+            Assert.Equal(CentrifugeSubscriptionState.Unsubscribed, sub.State);
+
+            client.Disconnect();
+        }
+
+        [Theory]
+        [MemberData(nameof(GetCentrifugeTransportEndpoints))]
+        public async Task Connect_ConcurrentCalls_DoNotCreateDuplicateTransport(CentrifugeTransportType transport, string endpoint)
+        {
+            // Bug 30: StartConnecting() called SetState(Connecting) without _stateChangeLock.
+            // Race: two concurrent Connect() calls both pass the unlocked state checks and both
+            // call StartConnecting(), each creating a separate transport. This causes duplicate
+            // Connected events, competing transports, and undefined client state.
+            // Fix: StartConnecting() re-checks state inside lock before SetState — only the first
+            // caller proceeds; subsequent callers see Connecting and return early.
+            //
+            // Run 50 iterations. With the fix exactly one Connected event fires per pair of
+            // concurrent Connect() calls.
+            for (int i = 0; i < 50; i++)
+            {
+                using var client = CreateClient(transport, endpoint, new CentrifugeClientOptions
+                {
+                    MinReconnectDelay = TimeSpan.FromSeconds(60),
+                    MaxReconnectDelay = TimeSpan.FromSeconds(60),
+                });
+
+                int connectedCount = 0;
+                var firstConnectedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                client.Connected += (_, _) =>
+                {
+                    Interlocked.Increment(ref connectedCount);
+                    firstConnectedTcs.TrySetResult(true);
+                };
+
+                // Fire two Connect() calls simultaneously from different threads.
+                // Without fix: both pass the unlocked state check (Disconnected) and both call
+                // StartConnecting() → SetState(Connecting) → CreateTransportAsync → Connected.
+                // With fix: StartConnecting() re-checks under lock; only one succeeds.
+                await Task.WhenAll(
+                    Task.Run(() => client.Connect()),
+                    Task.Run(() => client.Connect())
+                );
+
+                await firstConnectedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+                await Task.Delay(200); // let any duplicate connection attempt complete
+
+                Assert.Equal(1, connectedCount);
+                Assert.Equal(CentrifugeClientState.Connected, client.State);
+
+                client.Disconnect();
+                await client.ReadyAsync(TimeSpan.FromSeconds(5)).ContinueWith(_ => { }); // drain
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetCentrifugeTransportEndpoints))]
+        public async Task Subscribe_ConcurrentCalls_DoNotFireDuplicateSubscribingEvent(CentrifugeTransportType transport, string endpoint)
+        {
+            // Bug 31: Subscribe() checked state without _stateChangeLock, and StartSubscribing()
+            // called SetState(Subscribing) without _stateChangeLock. Race: two concurrent Subscribe()
+            // calls both pass the unlocked state checks (Unsubscribed) and both call StartSubscribing(),
+            // each firing a Subscribing event and potentially sending duplicate subscribe commands.
+            // Fix: Subscribe() checks state inside lock; StartSubscribing() re-checks under lock
+            // before SetState — only the first caller proceeds.
+            //
+            // Run 50 iterations. With the fix exactly one Subscribing event fires per pair of
+            // concurrent Subscribe() calls.
+            for (int i = 0; i < 50; i++)
+            {
+                using var client = CreateClient(transport, endpoint, new CentrifugeClientOptions
+                {
+                    MinReconnectDelay = TimeSpan.FromSeconds(60),
+                    MaxReconnectDelay = TimeSpan.FromSeconds(60),
+                });
+                client.Connect();
+                await client.ReadyAsync(TimeSpan.FromSeconds(5));
+
+                var sub = client.NewSubscription("test-subscribe-concurrent");
+
+                int subscribingCount = 0;
+                int subscribedCount = 0;
+                var firstSubscribedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                sub.Subscribing += (_, _) => Interlocked.Increment(ref subscribingCount);
+                sub.Subscribed += (_, _) =>
+                {
+                    Interlocked.Increment(ref subscribedCount);
+                    firstSubscribedTcs.TrySetResult(true);
+                };
+
+                // Fire two Subscribe() calls simultaneously from different threads.
+                // Without fix: both pass the unlocked state check (Unsubscribed) and both call
+                // StartSubscribing() → SetState(Subscribing) → fire Subscribing event.
+                // With fix: StartSubscribing() re-checks under lock; only one succeeds.
+                await Task.WhenAll(
+                    Task.Run(() => sub.Subscribe()),
+                    Task.Run(() => sub.Subscribe())
+                );
+
+                await firstSubscribedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+                await Task.Delay(200); // let any duplicate subscription attempt complete
+
+                Assert.Equal(1, subscribingCount);
+                Assert.Equal(1, subscribedCount);
+                Assert.Equal(CentrifugeSubscriptionState.Subscribed, sub.State);
+
+                sub.Unsubscribe();
+                client.Disconnect();
+                await client.ReadyAsync(TimeSpan.FromSeconds(5)).ContinueWith(_ => { }); // drain
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetCentrifugeTransportEndpoints))]
+        public async Task SendCommand_CallerCancellation_ThrowsOperationCanceled(CentrifugeTransportType transport, string endpoint)
+        {
+            // Verifies that when the caller's CancellationToken is cancelled,
+            // SendCommandAsync surfaces OperationCanceledException rather than CentrifugeTimeoutException.
+            // Pre-cancelled token guarantees the linked Task.Delay completes before any server reply
+            // arrives, so we exercise the cancellation-vs-timeout branch deterministically.
+            using var client = CreateClient(transport, endpoint, new CentrifugeClientOptions
+            {
+                Timeout = TimeSpan.FromSeconds(30),
+            });
+            client.Connect();
+            await client.ReadyAsync(TimeSpan.FromSeconds(5));
+
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            var rpcTask = client.RpcAsync("ping", ReadOnlyMemory<byte>.Empty, cts.Token);
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => rpcTask);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetCentrifugeTransportEndpoints))]
+        public async Task RpcAsync_QueuedDuringConnecting_FlushesAfterConnected(CentrifugeTransportType transport, string endpoint)
+        {
+            // The client admits commands while in Connecting state and adds them to the
+            // batch. Before the fix, the batch was only drained by the 1ms timer or by a
+            // subsequent enqueue. If the user issued an RpcAsync from the Connecting event
+            // handler and there were no subscriptions, the command sat in the batch up to
+            // the per-command timeout. The fix kicks a flush from HandleConnectReply.
+            using var client = CreateClient(transport, endpoint, new CentrifugeClientOptions
+            {
+                Timeout = TimeSpan.FromSeconds(10),
+            });
+
+            // Issue RPC during Connecting; expect it to complete quickly after connect.
+            Task<CentrifugeRpcResult>? rpcTask = null;
+            client.Connecting += (_, _) =>
+            {
+                // Echo handler doesn't need to exist server-side; we only care that the
+                // command flushes and either succeeds or fails fast (not hangs on timeout).
+                rpcTask = client.RpcAsync("ping", ReadOnlyMemory<byte>.Empty, CancellationToken.None);
+            };
+
+            client.Connect();
+            await client.ReadyAsync(TimeSpan.FromSeconds(5));
+
+            Assert.NotNull(rpcTask);
+            // Must complete (success or error) well under the 10s timeout — the kick
+            // from HandleConnectReply drives the flush even with no subscriptions.
+            using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+            try
+            {
+                await rpcTask!.WaitAsync(watchdog.Token);
+            }
+            catch (CentrifugeException)
+            {
+                // Server-side error (method not registered) is fine — we just need the flush to happen.
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetCentrifugeTransportEndpoints))]
+        public async Task RemoveSubscription_DisposesAndFreesChannelSlot(CentrifugeTransportType transport, string endpoint)
+        {
+            // After RemoveSubscription, the channel slot must be free and a new subscription
+            // must be createable for the same channel. Also verifies that the removed
+            // subscription does not leak: re-removing or operating on it is a no-op.
+            using var client = CreateClient(transport, endpoint);
+            client.Connect();
+            await client.ReadyAsync(TimeSpan.FromSeconds(5));
+
+            var channel = "test-remove-" + Guid.NewGuid().ToString("N").Substring(0, 8);
+
+            for (int i = 0; i < 10; i++)
+            {
+                var sub = client.NewSubscription(channel);
+                var subscribedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                sub.Subscribed += (_, _) => subscribedTcs.TrySetResult(true);
+                sub.Subscribe();
+                await subscribedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+                client.RemoveSubscription(sub);
+                Assert.False(client.Subscriptions.ContainsKey(channel));
+
+                // Calling Dispose again should be safe (idempotent).
+                sub.Dispose();
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetCentrifugeTransportEndpoints))]
+        public async Task PublicApi_AfterDispose_ThrowsObjectDisposedException(CentrifugeTransportType transport, string endpoint)
+        {
+            // After Dispose, public entry points must throw ObjectDisposedException rather than
+            // silently spinning up a new transport / subscription that nothing will clean up.
+            var client = CreateClient(transport, endpoint);
+            client.Connect();
+            await client.ReadyAsync(TimeSpan.FromSeconds(5));
+            client.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => client.Connect());
+            Assert.Throws<ObjectDisposedException>(() => client.NewSubscription("any"));
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => client.ReadyAsync(TimeSpan.FromSeconds(1)));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetCentrifugeTransportEndpoints))]
+        public async Task Subscribe_PermanentError_AllowsResubscribeFromUnsubscribedHandler(CentrifugeTransportType transport, string endpoint)
+        {
+            // Bug: a permanent subscribe error path entered SetUnsubscribedAsync with _inflight
+            // still set. If the user called Subscribe() from the Unsubscribed event handler,
+            // the new attempt observed _inflight=true and bailed; the outer finally then cleared
+            // _inflight, but nothing rescheduled the resub. The subscription stayed stuck in
+            // Subscribing.
+            //
+            // Fix: _inflight is now cleared BEFORE await SetUnsubscribedAsync in the permanent-error
+            // branch, mirroring the timeout/unauthorized/temporary patterns.
+            //
+            // We simulate a permanent error by subscribing to a server-side namespaced channel
+            // with no token — Centrifugo returns code 103 (unauthorized, non-temporary). The user's
+            // Unsubscribed handler then calls Subscribe() once more (also failing, but observable).
+            using var client = CreateClient(transport, endpoint);
+            client.Connect();
+            await client.ReadyAsync(TimeSpan.FromSeconds(5));
+
+            // "$" prefix in default Centrifugo config requires server-side authorization → token-less
+            // subscribe yields a non-temporary error (permanent).
+            var sub = client.NewSubscription("$forbidden");
+
+            int subscribingCount = 0;
+            var secondUnsubscribedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            int unsubscribedCount = 0;
+            sub.Subscribing += (_, _) => Interlocked.Increment(ref subscribingCount);
+            sub.Unsubscribed += (_, _) =>
+            {
+                if (Interlocked.Increment(ref unsubscribedCount) == 1)
+                {
+                    // Reentrant Subscribe from the handler. Before the fix this stuck in Subscribing
+                    // because _inflight was still held by the outer permanent-error path.
+                    sub.Subscribe();
+                }
+                else
+                {
+                    secondUnsubscribedTcs.TrySetResult(true);
+                }
+            };
+
+            sub.Subscribe();
+
+            // Second Unsubscribed must arrive — meaning the second Subscribe actually attempted
+            // (transitioned to Subscribing, hit the server again, came back as Unsubscribed).
+            await secondUnsubscribedTcs.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.True(subscribingCount >= 2, $"expected ≥2 Subscribing events, got {subscribingCount}");
+        }
+
+        [Theory]
+        [MemberData(nameof(GetCentrifugeTransportEndpoints))]
+        public async Task NextCommandId_SkipsZero_OnWraparound(CentrifugeTransportType transport, string endpoint)
+        {
+            // Bug: NextCommandId wraps through 0 on overflow; id=0 is reserved for push messages
+            // (no reply), so a wrap could collide with pushes. Fix: skip 0 in NextCommandId.
+            //
+            // We exercise the path directly via reflection to set _commandId near the wrap point.
+            using var client = CreateClient(transport, endpoint);
+            var clientField = typeof(CentrifugeClient).GetField("_commandId", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            Assert.NotNull(clientField);
+            // Set just before wrap so the next Interlocked.Increment yields 0 (after cast).
+            clientField!.SetValue(client, -1);
+
+            var nextMethod = typeof(CentrifugeClient).GetMethod("NextCommandId", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            Assert.NotNull(nextMethod);
+            var id = (uint)nextMethod!.Invoke(client, null)!;
+            Assert.NotEqual(0u, id);
         }
     }
 


### PR DESCRIPTION
# Reliability and thread-safety hardening

A multi-pass audit and fix campaign across the client, subscription, and transport layers.
The focus was on real, observable failure modes — connection stability, recovery correctness,
resource lifecycle, and deterministic behavior under concurrent use.

## What changed

**Concurrency and state machine.** Tightened lock discipline so that every read of `_state`
that branches behavior, every `SetState`, and every mutation of transport / pending-call /
CTS state happens under a single well-defined lock. Events are now always fired outside of
that lock, eliminating a class of deadlocks where user handlers re-entered the SDK. Per-state
generation counters (`_epoch`) prevent stale `getToken` results from being applied to a
re-established session.

**Resource lifecycle.** `CentrifugeSubscription` is now `IDisposable` and is disposed both
on `RemoveSubscription` and `Client.Dispose`. The public API (`Connect`, `Subscribe`,
`NewSubscription`, `ReadyAsync`, all command methods) now throws `ObjectDisposedException`
after disposal instead of silently spinning up a new transport that nothing will clean up.
HTTP response messages are properly disposed in the streaming transport. Browser transports
have an Interlocked cleanup guard so stale JS callbacks after teardown don't fire spurious
events.

**Protocol correctness.** The fire-and-forget `Send` path was bypassing varint framing and
was unusable over the emulation (`http_stream`) transport; it now routes through the same
framing/emulation pipeline as every other command. The fossil-delta `_prevValue` is now
reset on every subscribe reply so that a fresh server session can't be decoded against
stale bytes from the prior session. Stream-position and server-subscription offsets advance
monotonically. Commands queued while connecting are now flushed once the connection opens.

**Recovery and refresh.** Disconnect pushes now detach all transport event handlers before
kicking the reconnect path, so frames buffered between the disconnect signal and the actual
close can no longer fire user-facing events for a connection that is being torn down. `ttl == 0`
no longer schedules a zero-delay refresh timer. The reconnect `CancellationTokenSource`
lifetime races have been resolved with explicit ordering and `ObjectDisposedException`
guards.

**Cancellation semantics.** A caller-supplied `CancellationToken` now surfaces as
`OperationCanceledException`, distinct from the SDK's own `CentrifugeTimeoutException`, so
standard `.WaitAsync(ct)` patterns behave as expected.

## Testing

Added regression tests for the bug classes that produce a deterministic observable signal
(disposal contract, cancellation semantics, post-`Connecting` batch flush, re-entrant
`Subscribe` from `Unsubscribed` handlers, etc.). The integration suite — exercised against
both `websocket` and `http_stream` transports — runs to 147 tests, all green.