### PR TITLE
Support state invalidation

### DIFF
--- a/src/Centrifugal.Centrifuge/Client.cs
+++ b/src/Centrifugal.Centrifuge/Client.cs
@@ -2020,6 +2020,23 @@ namespace Centrifugal.Centrifuge
                 prevState = SetState(CentrifugeClientState.Connecting);
             }
 
+            if (code == CentrifugeDisconnectedCodes.StateInvalidated)
+            {
+                // State invalidated (delivered as a WebSocket close code or a Disconnect
+                // push — both funnel through here): drop the connection token so the next
+                // connect fetches a fresh one via GetToken, and invalidate every
+                // subscription's cached state before they move to subscribing below.
+                lock (_stateChangeLock)
+                {
+                    _options.Token = string.Empty;
+                    _refreshRequired = true;
+                }
+                foreach (var sub in _subscriptions.Values)
+                {
+                    sub.InvalidateState();
+                }
+            }
+
             // Move all subscribed subscriptions to subscribing state BEFORE emitting connecting event
             foreach (var sub in _subscriptions.Values)
             {
@@ -2691,6 +2708,12 @@ namespace Centrifugal.Centrifuge
                 }
                 else
                 {
+                    if (unsubscribe.Code == CentrifugeUnsubscribedCodes.StateInvalidated)
+                    {
+                        // State invalidated: drop the subscription token and cached
+                        // state so the resubscribe obtains a fresh token and re-syncs.
+                        clientSub.InvalidateState();
+                    }
                     // Temporary unsubscribe - resubscribe
                     _ = clientSub.ResubscribeAsync();
                 }

--- a/src/Centrifugal.Centrifuge/Enums.cs
+++ b/src/Centrifugal.Centrifuge/Enums.cs
@@ -212,6 +212,14 @@ namespace Centrifugal.Centrifuge
         /// Message size limit exceeded.
         /// </summary>
         public const int MessageSizeLimit = 3;
+
+        /// <summary>
+        /// State invalidated by the server: the connection token and/or cached
+        /// state are no longer valid. The client clears the connection token (to
+        /// force a fresh one via GetToken), invalidates all subscriptions, and
+        /// reconnects. Delivered as a WebSocket close code or a Disconnect push.
+        /// </summary>
+        public const int StateInvalidated = 3014;
     }
 
     /// <summary>
@@ -249,5 +257,13 @@ namespace Centrifugal.Centrifuge
         /// Client closed.
         /// </summary>
         public const int ClientClosed = 2;
+
+        /// <summary>
+        /// State invalidated by the server for this subscription: its token and/or
+        /// cached state are no longer valid. The client clears the subscription
+        /// token and cached state and resubscribes (this is a temporary unsubscribe
+        /// since the code is >= 2500).
+        /// </summary>
+        public const int StateInvalidated = 2502;
     }
 }

--- a/src/Centrifugal.Centrifuge/Subscription.cs
+++ b/src/Centrifugal.Centrifuge/Subscription.cs
@@ -790,6 +790,32 @@ namespace Centrifugal.Centrifuge
         /// whole registry on transport teardown, and on reconnect the server commonly
         /// assigns the same ID again — the registration must be restored.
         /// </summary>
+        // Resets cached subscription state on "state invalidated" (unsubscribe code
+        // 2502 or connection disconnect code 3014) so the resubscribe re-syncs:
+        // clears the token (and forces a fresh one via GetToken), the fossil delta
+        // base (a stale base would corrupt decoding of the first publication), and
+        // the channel-compaction ID mapping. The recovery position, when present
+        // (recoverable/positioned subscription), is reset to a sentinel epoch ("_")
+        // the server can never match — so the resubscribe reply reports
+        // WasRecovering=true, Recovered=false, letting the app reload via its
+        // existing recovery-failure path; a non-recoverable subscription has no
+        // stream position and simply resubscribes. The real epoch/offset are
+        // adopted from the subscribe reply.
+        internal void InvalidateState()
+        {
+            lock (_stateChangeLock)
+            {
+                _options.Token = string.Empty;
+                _refreshRequired = true;
+                if (_streamPosition != null)
+                {
+                    _streamPosition = new CentrifugeStreamPosition(0, "_");
+                }
+                _prevValue = null;
+                SetPushChannelId(0);
+            }
+        }
+
         private void SetPushChannelId(long id)
         {
             // Field and registry must change together under _stateChangeLock —

--- a/tests/Centrifugal.Centrifuge.Tests/StateInvalidationTests.cs
+++ b/tests/Centrifugal.Centrifuge.Tests/StateInvalidationTests.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Centrifugal.Centrifuge;
+using Centrifugal.Centrifuge.Protocol;
+using Xunit;
+
+namespace Centrifugal.Centrifuge.Tests
+{
+    /// <summary>
+    /// Tests for "state invalidated" handling: unsubscribe code 2502 (per-subscription)
+    /// and disconnect code 3014 (connection-wide). On these the client drops cached
+    /// tokens (and recovery position / delta base) so a fresh token is obtained and
+    /// the subscription re-syncs. Private fields aren't asserted directly; behavior is
+    /// observed over the wire against the in-process <see cref="FakeCentrifugoServer"/>.
+    /// </summary>
+    [Collection("Integration")]
+    public class StateInvalidationTests : IAsyncLifetime
+    {
+        private readonly FakeCentrifugoServer _server = new();
+        private CentrifugeClient? _client;
+
+        public async Task InitializeAsync()
+        {
+            await _server.StartAsync();
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (_client != null) await _client.DisposeAsync();
+            await _server.DisposeAsync();
+        }
+
+        private static System.Threading.Channels.Channel<T> NewChannel<T>() =>
+            System.Threading.Channels.Channel.CreateUnbounded<T>();
+
+        private string? LastConnectToken() =>
+            _server.Received.Where(c => c.Connect != null).Select(c => c.Connect.Token).LastOrDefault();
+
+        [Fact]
+        public async Task Unsubscribe2502ClearsSubTokenAndResubscribes()
+        {
+            _client = new CentrifugeClient(_server.Url, new CentrifugeClientOptions());
+            _client.Connect();
+            await _client.ReadyAsync();
+
+            var subscribedEvents = NewChannel<CentrifugeSubscribedEventArgs>();
+            var tokenCalls = 0;
+            var sub = _client.NewSubscription("ch", new CentrifugeSubscriptionOptions
+            {
+                GetToken = _ => Task.FromResult($"t{Interlocked.Increment(ref tokenCalls)}")
+            });
+            sub.Subscribed += (_, e) => subscribedEvents.Writer.TryWrite(e);
+            sub.Subscribe();
+            await subscribedEvents.Reader.ReadAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Equal("t1", _server.LastSubscribe()!.Token);
+
+            // Server sends "state invalidated" unsubscribe — the subscription must drop
+            // its token and resubscribe with a freshly fetched one.
+            await _server.SendPushAsync(new Push
+            {
+                Channel = "ch",
+                Unsubscribe = new Unsubscribe { Code = CentrifugeUnsubscribedCodes.StateInvalidated, Reason = "state invalidated" }
+            });
+
+            await subscribedEvents.Reader.ReadAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Equal("t2", _server.LastSubscribe()!.Token);
+        }
+
+        [Fact]
+        public async Task Unsubscribe2502RecoverableResubscribesUnrecovered()
+        {
+            // A recoverable subscription must resubscribe REQUESTING recovery from
+            // the sentinel epoch "_" the server can't match → was_recovering=true,
+            // recovered=false (so the app reloads via its recovery-failure path).
+            _server.OnSubscribe = (channel, req) =>
+                new SubscribeResult { Recoverable = true, Epoch = "server-epoch", Offset = 5 };
+
+            _client = new CentrifugeClient(_server.Url, new CentrifugeClientOptions());
+            _client.Connect();
+            await _client.ReadyAsync();
+
+            var subscribedEvents = NewChannel<CentrifugeSubscribedEventArgs>();
+            var sub = _client.NewSubscription("ch", new CentrifugeSubscriptionOptions());
+            sub.Subscribed += (_, e) => subscribedEvents.Writer.TryWrite(e);
+            sub.Subscribe();
+            await subscribedEvents.Reader.ReadAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.False(_server.LastSubscribe()!.Recover, "initial subscribe does not request recovery");
+
+            await _server.SendPushAsync(new Push
+            {
+                Channel = "ch",
+                Unsubscribe = new Unsubscribe { Code = CentrifugeUnsubscribedCodes.StateInvalidated, Reason = "state invalidated" }
+            });
+            await subscribedEvents.Reader.ReadAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+            var req = _server.LastSubscribe()!;
+            Assert.True(req.Recover, "resubscribe requests recovery (recover left true)");
+            Assert.Equal("_", req.Epoch);
+            Assert.Equal(0UL, req.Offset);
+        }
+
+        [Fact]
+        public async Task Disconnect3014ClearsConnTokenRefreshesAndInvalidatesSubs()
+        {
+            var connTokenCalls = 0;
+            _client = new CentrifugeClient(_server.Url, new CentrifugeClientOptions
+            {
+                Token = "conn-token-0",
+                GetToken = () => Task.FromResult($"conn-token-{Interlocked.Increment(ref connTokenCalls)}"),
+                MinReconnectDelay = TimeSpan.FromMilliseconds(10),
+                MaxReconnectDelay = TimeSpan.FromMilliseconds(100)
+            });
+            _client.Connect();
+            await _client.ReadyAsync();
+
+            var subscribedEvents = NewChannel<CentrifugeSubscribedEventArgs>();
+            var sub = _client.NewSubscription("ch", new CentrifugeSubscriptionOptions { Token = "sub-token-0" });
+            sub.Subscribed += (_, e) => subscribedEvents.Writer.TryWrite(e);
+            sub.Subscribe();
+            await subscribedEvents.Reader.ReadAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Equal("conn-token-0", LastConnectToken());
+
+            // Server sends "state invalidated" disconnect — the client must clear its
+            // connection token, fetch a fresh one via GetToken on reconnect, and
+            // invalidate the subscription (resubscribe with no token).
+            await _server.SendPushAsync(new Push
+            {
+                Disconnect = new Disconnect { Code = CentrifugeDisconnectedCodes.StateInvalidated, Reason = "state invalidated" }
+            });
+
+            // Second Subscribed event = reconnected + resubscribed.
+            await subscribedEvents.Reader.ReadAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.True(connTokenCalls >= 1, "connection token getter must be called after 3014");
+            Assert.Equal("conn-token-1", LastConnectToken());
+            Assert.Equal("", _server.LastSubscribe()!.Token);
+        }
+    }
+}


### PR DESCRIPTION
Handles server "state invalidated" signals so clients drop stale cached state and re-sync:

- **Unsubscribe code 2502** (per-subscription): clears the subscription token and cached state, then resubscribes.
- **Disconnect code 3014** (connection-wide): clears the connection token (forcing a fresh one via `GetToken`), invalidates every subscription, and reconnects. Funneled through `HandleTransportClosedAsync`, so it fires from **both** the Disconnect push and the WebSocket close frame.

`InvalidateState` clears the token, fossil delta base and channel-compaction id. When the subscription has a stream position (recoverable/positioned) it is reset to a sentinel epoch (`"_"`, offset 0) the server can never match, so the resubscribe reports `WasRecovering=true, Recovered=false` (the app reloads via its existing recovery-failure path); a subscription without a stream position simply resubscribes. The real epoch/offset are adopted from the subscribe reply.

Tests in `StateInvalidationTests.cs`: 2502 resubscribe, recoverable 2502 resubscribes unrecovered (`Recover=true, Epoch="_"`), 3014 connection-token refresh + sub invalidation.
