### PR TITLE
Fix token refresh scheduling for TTLs longer than ~49 days

### DIFF
--- a/src/Centrifugal.Centrifuge/Utilities.cs
+++ b/src/Centrifugal.Centrifuge/Utilities.cs
@@ -49,13 +49,24 @@ namespace Centrifugal.Centrifuge
         /// Converts TTL in seconds to milliseconds, accounting for clock skew.
         /// </summary>
         /// <param name="ttl">TTL in seconds.</param>
-        /// <returns>TTL in milliseconds, reduced by a small amount to account for network delays.</returns>
+        /// <returns>
+        /// TTL in milliseconds, reduced by a small amount to account for network delays,
+        /// clamped to <see cref="int.MaxValue"/> (~24.8 days).
+        /// </returns>
         public static int TtlToMilliseconds(uint ttl)
         {
             if (ttl == 0) return 0;
 
-            // Reduce by 5% to account for clock skew and network delays
-            double ms = ttl * 1000 * 0.95;
+            // Reduce by 5% to account for clock skew and network delays.
+            // Widen to double before multiplying: uint arithmetic wraps for TTLs above
+            // ~49 days (e.g. a 1 year token TTL), which would schedule the refresh far
+            // too early - a 49.7 day TTL wrapped to a ~670ms delay.
+            double ms = (double)ttl * 1000 * 0.95;
+
+            // Clamp so the result stays a valid Timer due time. Refreshing a token
+            // earlier than strictly necessary is harmless.
+            if (ms > int.MaxValue) return int.MaxValue;
+
             return (int)Math.Max(1, ms);
         }
     }

--- a/tests/Centrifugal.Centrifuge.Tests/UtilitiesTests.cs
+++ b/tests/Centrifugal.Centrifuge.Tests/UtilitiesTests.cs
@@ -93,6 +93,36 @@ namespace Centrifugal.Centrifuge.Tests
             // 100 seconds * 1000 * 0.95 = 95000ms
             Assert.Equal(95000, Utilities.TtlToMilliseconds(100));
         }
+
+        [Theory]
+        [InlineData(2592000u)]      // 30 days
+        [InlineData(3000000u)]      // ~34 days - exceeds int.MaxValue milliseconds
+        [InlineData(4294968u)]      // ~49.7 days - wraps uint milliseconds
+        [InlineData(31536000u)]     // 365 days
+        [InlineData(uint.MaxValue)]
+        public void TtlToMilliseconds_HugeTtl_ReturnsPositiveTimerSafeDelay(uint ttl)
+        {
+            var delay = Utilities.TtlToMilliseconds(ttl);
+
+            // Must stay a valid Timer due time: positive and <= int.MaxValue.
+            Assert.InRange(delay, 1, int.MaxValue);
+
+            // And must actually be usable as a Timer due time.
+            using var timer = new Timer(_ => { }, null, delay, Timeout.Infinite);
+        }
+
+        [Fact]
+        public void TtlToMilliseconds_IsMonotonic()
+        {
+            // A larger TTL must never schedule an earlier refresh.
+            uint[] ttls = { 1, 100, 86400, 2592000, 3000000, 4294968, 31536000, uint.MaxValue };
+            for (int i = 1; i < ttls.Length; i++)
+            {
+                Assert.True(
+                    Utilities.TtlToMilliseconds(ttls[i]) >= Utilities.TtlToMilliseconds(ttls[i - 1]),
+                    $"TtlToMilliseconds({ttls[i]}) < TtlToMilliseconds({ttls[i - 1]})");
+            }
+        }
     }
 
     public class VarintCodecTests


### PR DESCRIPTION
## What

`Utilities.TtlToMilliseconds(uint ttl)` computed `ttl * 1000` in **uint** arithmetic before widening to `double`. `uint` milliseconds wrap at ~49.7 days, so large token TTLs produced a wildly wrong (much too short) value:

| TTL | before | after |
| --- | --- | --- |
| 30 days | 2,462,400,000 ms → saturates to `int.MaxValue` | `int.MaxValue` (~24.8 days) |
| 49.7 days (`4294968` s) | **668 ms** | `int.MaxValue` |
| 365 days | ~16.2 days | `int.MaxValue` |

The result feeds `new Timer(..., delay, Timeout.Infinite)` in `CentrifugeClient.ScheduleConnectionRefresh` and `CentrifugeSubscription.ScheduleTokenRefresh`. So a connection or subscription token with a TTL just over 49.7 days would re-invoke the `GetToken` callback and send a `refresh` / `sub_refresh` command roughly **every 0.7 seconds** instead of once in seven weeks — hammering the app's token endpoint and the server. Notably it is not monotonic: a longer TTL could schedule an *earlier* refresh than a shorter one.

## Fix

Widen to `double` before multiplying, and clamp the result to `int.MaxValue` (~24.8 days) so it is always a valid `Timer` due time. Refreshing a long-lived token earlier than strictly necessary is harmless — the callback just runs sooner than the token needs.

No API change: `Utilities` is `internal`, and behavior for TTLs under ~24.8 days is unchanged.

## Tests

Added to `UtilitiesTests`:

- `TtlToMilliseconds_HugeTtl_ReturnsPositiveTimerSafeDelay` — theory over 30d / ~34d / ~49.7d / 365d / `uint.MaxValue`, asserting the value is in `[1, int.MaxValue]` and actually accepted by a `Timer`.
- `TtlToMilliseconds_IsMonotonic` — a larger TTL must never schedule an earlier refresh.

`TtlToMilliseconds_IsMonotonic` fails on `main` (`TtlToMilliseconds(4294968) < TtlToMilliseconds(3000000)`) and passes with this change.

## Verification

`dotnet build Centrifugal.Centrifuge.sln --configuration Release` — clean across all target frameworks (netstandard2.1, net6.0, net8.0, net9.0, net10.0), 0 warnings.

`dotnet test Centrifugal.Centrifuge.sln --configuration Release --filter "FullyQualifiedName!~IntegrationTests"` — **80 passed, 0 failed** (74 before, +6 new). This is the same command CI runs on the macOS/Windows matrix legs.

The integration suite was not run locally: it needs a dedicated Centrifugo on `localhost:8000` with this repo's `docker-compose.yml` config, and that port was occupied by an unrelated container with a different configuration. CI will run it on the ubuntu leg. The change is confined to a pure arithmetic helper with no transport or protocol involvement.