### PR TITLE
Remove leftover console.log debug calls from BrowserWebSocketTransport

### DIFF
--- a/src/Centrifugal.Centrifuge/Transports/BrowserWebSocketTransport.cs
+++ b/src/Centrifugal.Centrifuge/Transports/BrowserWebSocketTransport.cs
@@ -273,8 +273,6 @@ namespace Centrifugal.Centrifuge.Transports
         public void OnClose(object? codeObj, object? reasonObj)
         {
             if (System.Threading.Interlocked.CompareExchange(ref _cleanupStarted, 0, 0) != 0) return;
-            // Log directly via JavaScript to ensure it shows up
-            _ = _jsRuntime.InvokeVoidAsync("console.log", "[C#] OnClose called with codeObj:", codeObj, "reasonObj:", reasonObj);
 
             _logger?.LogDebug($"OnClose START - codeObj type: {codeObj?.GetType()?.Name ?? "null"}, value: {codeObj}, reasonObj type: {reasonObj?.GetType()?.Name ?? "null"}, value: '{reasonObj}'");
 
@@ -298,8 +296,6 @@ namespace Centrifugal.Centrifuge.Transports
             _isOpen = false;
             var args = new TransportClosedEventArgs(code, reason);
             _logger?.LogDebug($"OnClose - created args with Code: {args.Code}, Reason: '{args.Reason}'");
-
-            _ = _jsRuntime.InvokeVoidAsync("console.log", "[C#] Firing Closed event with Code:", args.Code, "Reason:", args.Reason);
 
             Closed?.Invoke(this, args);
             _ = CleanupAsync();


### PR DESCRIPTION
## What changed

Removes two unconditional JS-interop `console.log` calls in `BrowserWebSocketTransport.OnClose` (lines with the `"[C#] ..."` prefix and the comment "Log directly via JavaScript to ensure it shows up"). They are clearly leftover ad-hoc debugging artifacts from developing the Blazor WASM WebSocket interop.

## Why

`OnClose` fires on every WebSocket close for every consumer of this SDK, including production Blazor WASM apps. The two `console.log` calls write internal library state (close code/reason, event args) directly to the browser's console unconditionally, bypassing the `_logger?.LogDebug(...)` gating that every other diagnostic line in this class (and the sibling `BrowserHttpStreamTransport`, which has no such calls) already uses. This pollutes end users' browser consoles on every disconnect for no benefit — the `LogDebug` calls immediately above/below each removed line already carry the same information for anyone who has debug logging enabled.

## Verification

- `dotnet build Centrifugal.Centrifuge.sln -c Debug` — succeeds, 0 warnings, 0 errors.
- Full test suite (`dotnet test tests/Centrifugal.Centrifuge.Tests`) against a local Centrifugo v6 instance (`docker compose up`): 173/173 passed.
- No regression test added: this isn't a functional behavior change (no return values, timing, or state transitions differ), just removal of stray console output from Blazor WASM JS interop, which isn't observable from the existing xUnit suite (there's no browser/JS-interop test harness in this repo). Confirmed via `grep` that no other `console.log`/`console.error`/`console.warn` calls remain anywhere in `src/`.