### PR TITLE
Reset server-side subscription recovery position on state invalidation

### DIFF
--- a/src/Centrifugal.Centrifuge/Client.cs
+++ b/src/Centrifugal.Centrifuge/Client.cs
@@ -2035,6 +2035,26 @@ namespace Centrifugal.Centrifuge
                 {
                     sub.InvalidateState();
                 }
+
+                // Server-side subscriptions aren't Subscription objects and so don't go
+                // through InvalidateState() above — reset their cached recovery position
+                // here too, or the reconnect's Connect request would keep requesting
+                // recovery from the now-stale pre-invalidation offset/epoch, defeating
+                // the point of state invalidation. Recoverable is left untouched, only
+                // the position is reset to the sentinel epoch "_" the server can never
+                // match, mirroring InvalidateState()'s handling of client-side subs.
+                foreach (var channel in _serverSubscriptions.Keys)
+                {
+                    if (_serverSubscriptions.TryGetValue(channel, out var existing))
+                    {
+                        _serverSubscriptions[channel] = new ServerSubscription
+                        {
+                            Offset = 0,
+                            Epoch = "_",
+                            Recoverable = existing.Recoverable
+                        };
+                    }
+                }
             }
 
             // Move all subscribed subscriptions to subscribing state BEFORE emitting connecting event

--- a/src/Centrifugal.Centrifuge/Client.cs
+++ b/src/Centrifugal.Centrifuge/Client.cs
@@ -2045,14 +2045,17 @@ namespace Centrifugal.Centrifuge
                 // match, mirroring InvalidateState()'s handling of client-side subs.
                 foreach (var channel in _serverSubscriptions.Keys)
                 {
-                    if (_serverSubscriptions.TryGetValue(channel, out var existing))
+                    lock (_stateChangeLock)
                     {
-                        _serverSubscriptions[channel] = new ServerSubscription
+                        if (_serverSubscriptions.TryGetValue(channel, out var existing))
                         {
-                            Offset = 0,
-                            Epoch = "_",
-                            Recoverable = existing.Recoverable
-                        };
+                            _serverSubscriptions[channel] = new ServerSubscription
+                            {
+                                Offset = 0,
+                                Epoch = "_",
+                                Recoverable = existing.Recoverable
+                            };
+                        }
                     }
                 }
             }

--- a/tests/Centrifugal.Centrifuge.Tests/StateInvalidationTests.cs
+++ b/tests/Centrifugal.Centrifuge.Tests/StateInvalidationTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -99,6 +100,74 @@ namespace Centrifugal.Centrifuge.Tests
             Assert.True(req.Recover, "resubscribe requests recovery (recover left true)");
             Assert.Equal("_", req.Epoch);
             Assert.Equal(0UL, req.Offset);
+        }
+
+        [Fact]
+        public async Task Disconnect3014ResetsServerSubRecoveryPosition()
+        {
+            // A server-side subscription (pushed via the Connect reply's Subs field,
+            // not a client-side CentrifugeSubscription) is recoverable with a cached
+            // position from the very first connect. A 3014 disconnect must reset that
+            // cached offset/epoch to the sentinel too, or the reconnect keeps
+            // requesting recovery from the now-stale pre-invalidation position —
+            // defeating the point of state invalidation.
+            _server.ConnectResult = new ConnectResult
+            {
+                Client = "fake-client",
+                Version = "0.0.0",
+                Ping = 25,
+                Subs =
+                {
+                    ["ch"] = new SubscribeResult
+                    {
+                        Recoverable = true,
+                        Positioned = true,
+                        Epoch = "server-epoch",
+                        Offset = 42
+                    }
+                }
+            };
+
+            _client = new CentrifugeClient(_server.Url, new CentrifugeClientOptions
+            {
+                GetToken = () => Task.FromResult("conn-token"),
+                MinReconnectDelay = TimeSpan.FromMilliseconds(10),
+                MaxReconnectDelay = TimeSpan.FromMilliseconds(100)
+            });
+
+            var serverSubscribedEvents = NewChannel<CentrifugeServerSubscribedEventArgs>();
+            _client.ServerSubscribed += (_, e) => serverSubscribedEvents.Writer.TryWrite(e);
+
+            _client.Connect();
+            await _client.ReadyAsync();
+            await serverSubscribedEvents.Reader.ReadAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+            List<ConnectRequest> Connects() =>
+                _server.Received.Where(c => c.Connect != null).Select(c => c.Connect).ToList();
+
+            // First connect has no cached position yet, so it doesn't request recovery.
+            var firstConnects = Connects();
+            Assert.Single(firstConnects);
+            Assert.False(firstConnects[0].Subs.ContainsKey("ch"), "initial connect does not request recovery");
+
+            // Server sends "state invalidated" disconnect — the client must reset the
+            // server-side subscription's cached recovery position before reconnecting.
+            await _server.SendPushAsync(new Push
+            {
+                Disconnect = new Disconnect { Code = CentrifugeDisconnectedCodes.StateInvalidated, Reason = "state invalidated" }
+            });
+
+            // Second ServerSubscribed event = reconnected and server subs reprocessed.
+            await serverSubscribedEvents.Reader.ReadAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+            var connects = Connects();
+            Assert.True(connects.Count >= 2, "expected a reconnect Connect command");
+            var reconnectRequest = connects[1];
+            Assert.True(reconnectRequest.Subs.ContainsKey("ch"), "reconnect requests recovery for server-side sub");
+            var subReq = reconnectRequest.Subs["ch"];
+            Assert.True(subReq.Recover, "recoverable flag preserved");
+            Assert.Equal("_", subReq.Epoch);
+            Assert.Equal(0UL, subReq.Offset);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary

On disconnect code 3014 ("state invalidated"), the client already resets each **client-side** `Subscription`'s cached recovery position (offset/epoch) to the sentinel (offset `0`, epoch `"_"`) via `InvalidateState()`, so the next resubscribe can't recover from now-invalid state.

**Server-side subscriptions** (pushed via the Connect reply's `Subs` field, tracked in `_serverSubscriptions` in `src/Centrifugal.Centrifuge/Client.cs`) were left untouched by the 3014 handling. `BuildConnectCommandObjectAsync`/`SendConnectCommandAsync` unconditionally send each recoverable server-side sub's cached offset/epoch as recovery params on every connect, so an app using only server-side subscriptions kept requesting recovery from the stale pre-invalidation position after a 3014 disconnect — defeating the entire point of state invalidation.

## Fix

In the 3014 handling block in `Client.cs`, after invalidating client-side subscriptions, also reset every `_serverSubscriptions` entry's `Offset` to `0` and `Epoch` to `"_"`, leaving `Recoverable` untouched — mirroring exactly what `InvalidateState()` already does for client-side subscriptions.

I also checked whether this client had the same token-refresh-hang bug that required a follow-up fix in centrifuge-swift (forcing the reconnect through the token-refresh path even with no token getter configured, causing a hang). It does not: `BuildConnectCommandObjectAsync`/`SendConnectCommandAsync` only attempt `GetToken()` when `_options.GetToken != null`, and otherwise proceed with the existing token. No change was needed there.

## Test plan

- [x] Added `Disconnect3014ResetsServerSubRecoveryPosition` in `tests/Centrifugal.Centrifuge.Tests/StateInvalidationTests.cs`: connects with a recoverable server-push subscription (via the fake server's `ConnectResult.Subs`), asserts the first connect doesn't request recovery, triggers a 3014 `Disconnect` push, and asserts the reconnect's `Connect` request now carries `Recover=true` with `Epoch="_"` and `Offset=0` for that channel.
- [x] `dotnet build Centrifugal.Centrifuge.sln` — succeeds, 0 warnings/errors.
- [x] `dotnet test tests/Centrifugal.Centrifuge.Tests/Centrifugal.Centrifuge.Tests.csproj --filter "FullyQualifiedName!~IntegrationTests"` — 83/83 passed (IntegrationTests excluded as they require a live Centrifugo server, per the repo's own `make test-unit` target).

Mirrors the same fix applied in centrifugal/centrifuge-swift#135 and centrifugal/centrifuge-js#385.