### PR TITLE
Remove stale server-side subscriptions when connect reply has no subs

### DIFF
--- a/src/Centrifugal.Centrifuge/Client.cs
+++ b/src/Centrifugal.Centrifuge/Client.cs
@@ -2589,14 +2589,13 @@ namespace Centrifugal.Centrifuge
 
         private void ProcessServerSubscriptions(Google.Protobuf.Collections.MapField<string, SubscribeResult> subs)
         {
-            if (subs == null || subs.Count == 0)
-            {
-                return;
-            }
-
             var subsToKeep = new HashSet<string>();
 
-            // Process new/updated subscriptions
+            // Process new/updated subscriptions. An empty map is NOT an early exit: it
+            // means the connection no longer carries any server-side subscription, so
+            // every previously known one must still be dropped by the cleanup loop
+            // below — otherwise ServerUnsubscribed is never raised for it and the next
+            // connect command keeps asking to recover a channel we're not in anymore.
             foreach (var kvp in subs)
             {
                 var channel = kvp.Key;

--- a/tests/Centrifugal.Centrifuge.Tests/ServerSubscriptionTests.cs
+++ b/tests/Centrifugal.Centrifuge.Tests/ServerSubscriptionTests.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Centrifugal.Centrifuge;
+using Centrifugal.Centrifuge.Protocol;
+using Xunit;
+
+namespace Centrifugal.Centrifuge.Tests
+{
+    /// <summary>
+    /// Tests for server-side subscriptions (the ones carried by the connect reply's
+    /// subs map, not created with NewSubscription). Behavior is observed over the wire
+    /// against the in-process <see cref="FakeCentrifugoServer"/>.
+    /// </summary>
+    [Collection("Integration")]
+    public class ServerSubscriptionTests : IAsyncLifetime
+    {
+        private readonly FakeCentrifugoServer _server = new();
+        private CentrifugeClient? _client;
+
+        public async Task InitializeAsync()
+        {
+            await _server.StartAsync();
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (_client != null) await _client.DisposeAsync();
+            await _server.DisposeAsync();
+        }
+
+        private static System.Threading.Channels.Channel<T> NewChannel<T>() =>
+            System.Threading.Channels.Channel.CreateUnbounded<T>();
+
+        [Fact]
+        public async Task ConnectReplyWithoutSubsUnsubscribesPreviousServerSubs()
+        {
+            // First connect: server hands the client one recoverable server-side sub.
+            _server.ConnectResult = new ConnectResult
+            {
+                Client = "fake-client",
+                Version = "0.0.0",
+                Ping = 25,
+                Subs =
+                {
+                    ["srv"] = new SubscribeResult { Recoverable = true, Positioned = true, Epoch = "e1", Offset = 7 }
+                }
+            };
+
+            var subscribed = NewChannel<CentrifugeServerSubscribedEventArgs>();
+            var unsubscribed = NewChannel<CentrifugeServerUnsubscribedEventArgs>();
+
+            _client = new CentrifugeClient(_server.Url, new CentrifugeClientOptions());
+            _client.ServerSubscribed += (_, e) => subscribed.Writer.TryWrite(e);
+            _client.ServerUnsubscribed += (_, e) => unsubscribed.Writer.TryWrite(e);
+            _client.Connect();
+            await _client.ReadyAsync();
+
+            var first = await subscribed.Reader.ReadAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Equal("srv", first.Channel);
+
+            // The connection drops and the connect reply now carries NO server subs —
+            // the user is no longer subscribed to "srv" server-side.
+            _server.ConnectResult = new ConnectResult { Client = "fake-client", Version = "0.0.0", Ping = 25 };
+            _server.CloseConnection();
+
+            var gone = await unsubscribed.Reader.ReadAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.Equal("srv", gone.Channel);
+
+            // ...and the sub must be forgotten, so a further reconnect no longer asks
+            // the server to recover a channel the connection has nothing to do with.
+            var connectsBefore = _server.Received.Count(c => c.Connect != null);
+            _server.CloseConnection();
+            await WaitUntilAsync(
+                () => _server.Received.Count(c => c.Connect != null) > connectsBefore,
+                TimeSpan.FromSeconds(10));
+
+            var lastConnect = _server.Received.Last(c => c.Connect != null).Connect;
+            Assert.DoesNotContain("srv", lastConnect.Subs.Keys);
+        }
+
+        [Fact]
+        public async Task ConnectReplyWithSubsKeepsRecoveryPositionAcrossReconnect()
+        {
+            // Sanity companion to the test above: while the server keeps returning the
+            // sub, the client must keep recovering it from the tracked position.
+            _server.ConnectResult = new ConnectResult
+            {
+                Client = "fake-client",
+                Version = "0.0.0",
+                Ping = 25,
+                Subs =
+                {
+                    ["srv"] = new SubscribeResult { Recoverable = true, Positioned = true, Epoch = "e1", Offset = 7 }
+                }
+            };
+
+            var subscribed = NewChannel<CentrifugeServerSubscribedEventArgs>();
+            _client = new CentrifugeClient(_server.Url, new CentrifugeClientOptions());
+            _client.ServerSubscribed += (_, e) => subscribed.Writer.TryWrite(e);
+            _client.Connect();
+            await _client.ReadyAsync();
+            await subscribed.Reader.ReadAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+            var connectsBefore = _server.Received.Count(c => c.Connect != null);
+            _server.CloseConnection();
+            await WaitUntilAsync(
+                () => _server.Received.Count(c => c.Connect != null) > connectsBefore,
+                TimeSpan.FromSeconds(10));
+
+            var lastConnect = _server.Received.Last(c => c.Connect != null).Connect;
+            Assert.True(lastConnect.Subs.TryGetValue("srv", out var recover));
+            Assert.True(recover!.Recover);
+            Assert.Equal(7UL, recover.Offset);
+            Assert.Equal("e1", recover.Epoch);
+        }
+
+        private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+        {
+            var deadline = DateTime.UtcNow + timeout;
+            while (DateTime.UtcNow < deadline)
+            {
+                if (condition()) return;
+                await Task.Delay(25);
+            }
+            throw new TimeoutException("condition not met in time");
+        }
+    }
+}


### PR DESCRIPTION
## What

`CentrifugeClient.ProcessServerSubscriptions` returned early when the connect reply's `subs` map was empty:

```csharp
if (subs == null || subs.Count == 0)
{
    return;
}
```

That early return skips the cleanup loop at the bottom of the method — the one that removes server-side subscriptions the connection no longer carries and raises `ServerUnsubscribed` for them.

## Why it's a bug

An empty `subs` map is meaningful, not a no-op: it means "this connection has no server-side subscriptions". So if a client is server-side subscribed to a channel and then reconnects with a connect reply that contains no subs at all (e.g. the connection token no longer grants any server-side channel, or the server's config changed), the client:

1. never raises `ServerUnsubscribed`, so the app keeps believing it is subscribed; and
2. keeps the entry in `_serverSubscriptions` forever, so `BuildConnectCommandObjectAsync` keeps adding a `recover: true` sub request for that channel to **every** subsequent connect command.

The partial case (reply drops *some* but not all subs) already worked, because `subs.Count > 0` let the cleanup loop run — only the all-gone case was broken.

`centrifuge-js` has no such early return: `_connectResponse` calls `this._processServerSubs(result.subs || {})` and `_processServerSubs` always runs its final `for (const channel in this._serverSubs) { if (!subs[channel]) { emit('unsubscribed'); delete ... } }` loop, even for an empty map.

## The fix

Drop the early return so the cleanup loop always runs. The `subs == null` guard goes with it — the parameter is a non-nullable `MapField<string, SubscribeResult>` and protobuf-generated map fields are never null. No behavior change for non-empty replies; no public API change.

## Verification

Added `tests/Centrifugal.Centrifuge.Tests/ServerSubscriptionTests.cs`, driven by the existing in-process `FakeCentrifugoServer` (no Docker needed for these two).

- `ConnectReplyWithoutSubsUnsubscribesPreviousServerSubs` — the regression test. Connects with a connect reply carrying one recoverable/positioned server sub `srv` (epoch `e1`, offset 7) and asserts `ServerSubscribed`. Then swaps the fake's `ConnectResult` for one with no subs and aborts the connection to force a reconnect. Asserts (a) `ServerUnsubscribed` fires for `srv`, and (b) after one more reconnect the connect command's `Subs` no longer contains `srv`.
  - **Before the fix**: hangs on (a) and fails with `System.TimeoutException` after 10s — `ServerUnsubscribed` is never raised. (b) is unreachable but would fail too, since the entry is still in `_serverSubscriptions`.
  - **After the fix**: passes in ~0.5s.
- `ConnectReplyWithSubsKeepsRecoveryPositionAcrossReconnect` — companion guard so the fix can't be "fixed" by simply forgetting server subs. Asserts that while the server keeps returning `srv`, the reconnect's connect command still carries `recover: true`, `offset: 7`, `epoch: e1`. Passes both before and after.

Both tests are kept: they cover a real class of regression (server-sub lifecycle across reconnects, which had no coverage at all before), they assert over-the-wire protocol behavior rather than private fields, and they're fast and Docker-free.

Full suite run against `docker compose up` Centrifugo v6.8.2: **176/176 passed** (`dotnet test Centrifugal.Centrifuge.sln --configuration Release`). Release build clean, 0 warnings (the project builds with `TreatWarningsAsErrors`).