### PR TITLE
Skip sending unsubscribe command when transport is not open

### DIFF
--- a/src/Centrifugal.Centrifuge/Subscription.cs
+++ b/src/Centrifugal.Centrifuge/Subscription.cs
@@ -1123,6 +1123,16 @@ namespace Centrifugal.Centrifuge
                     ClearRefreshTimer();
                 }
 
+                // Only tell the server when there is a live session to tell. Without an
+                // open transport the subscription has no server-side counterpart, so the
+                // command is pointless — and while the client is still connecting it
+                // would sit in the command batch until the connect completes. If that
+                // takes longer than the per-command timeout the send fails, and that
+                // failure is treated as an unsubscribe error that forces a needless
+                // reconnect. Matches centrifuge-js (_unsubscribe returns early when the
+                // transport is not open).
+                if (!_client.TransportIsOpen) return;
+
                 try
                 {
                     var cmd = new Command

--- a/tests/Centrifugal.Centrifuge.Tests/FakeCentrifugoServer.cs
+++ b/tests/Centrifugal.Centrifuge.Tests/FakeCentrifugoServer.cs
@@ -66,6 +66,12 @@ namespace Centrifugal.Centrifuge.Tests
         /// <summary>Customize the subscribe result per channel (default: empty result).</summary>
         public Func<string, SubscribeRequest, SubscribeResult>? OnSubscribe { get; set; }
 
+        /// <summary>
+        /// Awaited before the WebSocket handshake is accepted. Lets a test hold the
+        /// client in the transport-opening phase (transport created, not yet open).
+        /// </summary>
+        public Func<Task>? BeforeAccept { get; set; }
+
         public string Url { get; private set; } = "";
 
         /// <summary>A copy of all commands received from the client, in order.</summary>
@@ -101,6 +107,8 @@ namespace Centrifugal.Centrifuge.Tests
                     context.Response.StatusCode = 400;
                     return;
                 }
+                var beforeAccept = BeforeAccept;
+                if (beforeAccept != null) await beforeAccept();
                 var ws = await context.WebSockets.AcceptWebSocketAsync("centrifuge-protobuf");
                 lock (_lock)
                 {

--- a/tests/Centrifugal.Centrifuge.Tests/UnsubscribeWhileConnectingTests.cs
+++ b/tests/Centrifugal.Centrifuge.Tests/UnsubscribeWhileConnectingTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Centrifugal.Centrifuge;
+using Xunit;
+
+namespace Centrifugal.Centrifuge.Tests
+{
+    /// <summary>
+    /// Unsubscribe() while the client is still connecting must not send an
+    /// unsubscribe command. There is no server-side session to remove the
+    /// subscription from, and the command would sit in the batch until the connect
+    /// completes — past the per-command timeout when the connect is slow — where
+    /// its failure is treated as an unsubscribe error and forces a needless
+    /// reconnect. Mirrors centrifuge-js, whose _unsubscribe returns early when the
+    /// transport is not open.
+    /// </summary>
+    [Collection("Integration")]
+    public class UnsubscribeWhileConnectingTests : IAsyncLifetime
+    {
+        private readonly FakeCentrifugoServer _server = new();
+        private CentrifugeClient? _client;
+
+        public Task InitializeAsync() => _server.StartAsync();
+
+        public async Task DisposeAsync()
+        {
+            if (_client != null) await _client.DisposeAsync();
+            await _server.DisposeAsync();
+        }
+
+        [Fact]
+        public async Task UnsubscribeWhileTransportOpeningSendsNothingAndKeepsConnecting()
+        {
+            // Hold the WebSocket handshake so the client stays in Connecting with a
+            // transport that exists but is not open yet.
+            var handshakeStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseHandshake = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            _server.BeforeAccept = () =>
+            {
+                handshakeStarted.TrySetResult();
+                return releaseHandshake.Task;
+            };
+
+            try
+            {
+                var connecting = System.Threading.Channels.Channel.CreateUnbounded<CentrifugeConnectingEventArgs>();
+                _client = new CentrifugeClient(_server.Url, new CentrifugeClientOptions
+                {
+                    // Short per-command timeout so a queued unsubscribe would fail quickly.
+                    Timeout = TimeSpan.FromMilliseconds(300),
+                });
+                _client.Connecting += (_, e) => connecting.Writer.TryWrite(e);
+
+                var sub = _client.NewSubscription("news");
+                sub.Subscribe();
+                _client.Connect();
+                await handshakeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+                Assert.Equal(CentrifugeClientState.Connecting, _client.State);
+
+                sub.Unsubscribe();
+                Assert.Equal(CentrifugeSubscriptionState.Unsubscribed, sub.State);
+
+                // Well past the command timeout: a queued unsubscribe would have failed
+                // by now and dragged the client through a reconnect.
+                await Task.Delay(1000);
+
+                var first = await connecting.Reader.ReadAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+                Assert.Equal(CentrifugeConnectingCodes.ConnectCalled, first.Code);
+                Assert.False(connecting.Reader.TryRead(out var extra),
+                    $"unexpected Connecting event: code={extra?.Code} reason='{extra?.Reason}'");
+                Assert.Equal(CentrifugeClientState.Connecting, _client.State);
+
+                // Let the handshake through: the client connects normally and the server
+                // never sees a subscribe or an unsubscribe for the abandoned subscription.
+                releaseHandshake.TrySetResult();
+                await _client.ReadyAsync(TimeSpan.FromSeconds(5));
+                await Task.Delay(200);
+                Assert.DoesNotContain(_server.Received, c => c.Unsubscribe != null);
+                Assert.DoesNotContain(_server.Received, c => c.Subscribe != null);
+                Assert.Equal(CentrifugeSubscriptionState.Unsubscribed, sub.State);
+            }
+            finally
+            {
+                releaseHandshake.TrySetResult();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What changed

`CentrifugeSubscription.SetUnsubscribedAsync` now returns early, without sending an `unsubscribe` command, when the client transport is not open.

## Why

Calling `Unsubscribe()` while the client is still connecting (transport created, but the WebSocket handshake or the connect reply not yet completed) queued an `unsubscribe` command in the command batch. The batch is only flushed once the connect reply arrives. If the connect took longer than the per-command `Timeout`, the queued command failed with a timeout, and `SetUnsubscribedAsync` treats any non-disconnect failure as an unsubscribe error and answers with a forced reconnect (`Connecting` event with code 4, "unsubscribe error"). Even when the connect was fast enough, the command was still sent for a subscription the new session never had. The Go server treats an unsubscribe for an unknown channel as a no-op, so that part was only wasted traffic; the spurious reconnect is the real problem, and it is most likely to hit on slow or unstable networks.

Without an open transport the subscription has no server-side counterpart, so there is nothing to tell the server. This mirrors centrifuge-js, whose `_unsubscribe` returns immediately when `_transportIsOpen` is false.

`Dispose()`/`DisposeAsync()` paths are unaffected in outcome: they already ran after transport cleanup, so the send threw `ClientDisconnected` and was swallowed; now it is skipped up front.

## Verification

Regression test `UnsubscribeWhileConnectingTests.UnsubscribeWhileTransportOpeningSendsNothingAndKeepsConnecting` (kept in the tree):

- Adds a small `BeforeAccept` hook to `FakeCentrifugoServer` that is awaited before the WebSocket handshake is accepted, so the test can hold the client in the transport-opening phase.
- Creates a client with a 300 ms `Timeout`, subscribes to a channel, connects, waits until the handshake has started, and calls `Unsubscribe()`.
- After 1 s asserts that the only `Connecting` event is the initial "connect called" one and that the client is still `Connecting`; then releases the handshake, waits for `ReadyAsync`, and asserts the server received neither a `subscribe` nor an `unsubscribe` command.

Before the fix the test failed with `unexpected Connecting event: code=4 reason='unsubscribe error'`. It passes with the fix. It is kept because it guards a distinct class of regression (commands issued while connecting being escalated into reconnects) that no existing test covers, and it only relies on public client state plus the fake server's wire capture.

Also ran the full suite (`dotnet test Centrifugal.Centrifuge.sln -c Release`) against a local Centrifugo from `docker-compose.yml`: 179 passed, 0 failed.
